### PR TITLE
Drop support for Typesense v0.25.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
     strategy:
       matrix:
         include:
-        - typesense: '0.25.2'
+        - typesense: '26.0'
           otp: '25'
           elixir: '1.14'
           lint: false
-        - typesense: '26.0'
+        - typesense: '27.0'
           otp: '25'
           elixir: '1.14'
           lint: false
@@ -41,17 +41,17 @@ jobs:
           otp: '25'
           elixir: '1.14'
           lint: false
-        - typesense: '0.25.2'
-          otp: '27'
-          elixir: '1.17'
-          lint: false
         - typesense: '26.0'
           otp: '27'
-          elixir: '1.17'
+          elixir: '1.18'
+          lint: false
+        - typesense: '27.0'
+          otp: '27'
+          elixir: '1.18'
           lint: false
         - typesense: '27.1'
           otp: '27'
-          elixir: '1.17'
+          elixir: '1.18'
           lint: true
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,8 @@ jobs:
           -v /tmp/typesense-data:/data \
           -v /tmp/typesense-analytics-data:/analytics-data \
           typesense/typesense:${{ matrix.typesense}} \
-          --api-key=xyz \
-          --data-dir=/data \
+          --api-key xyz \
+          --data-dir /data \
           --enable-search-analytics=true \
           --analytics-dir=/analytics-data  \
           --analytics-flush-interval=60 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## major.minor.patch (yyyy.mm.dd)
 
+## 0.6.0 (2025.01.19)
+
+### Changed
+
+* CI to support Typesense versions v26.0, v27.0, v27.1
+
+### Removed
+
+* Support for Typesense version v0.25.2
+
 ## 0.5.2 (2025.01.16)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Restful client for Typesense with adherence to Open API spec 3 (formerly Swagger
 [![Hex.pm](https://img.shields.io/hexpm/v/open_api_typesense)](https://hex.pm/packages/open_api_typesense)
 [![Hexdocs.pm](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/open_api_typesense)
 [![Hex.pm](https://img.shields.io/hexpm/l/open_api_typesense)](https://hexdocs.pm/open_api_typesense/license.html)
-[![Typesense badge](https://img.shields.io/badge/Typesense-v27.1-darkblue)](https://typesense.org/docs/27.1/api)
+[![Typesense badge](https://img.shields.io/badge/Typesense-v26.0_%7C_v27.0_%7C_v27.1-darkblue)](https://typesense.org/docs/27.1/api)
 [![Coverage Status](https://coveralls.io/repos/github/jaeyson/open_api_typesense/badge.svg?branch=main)](https://coveralls.io/github/jaeyson/open_api_typesense?branch=main)
 [![CI Status](https://github.com/jaeyson/open_api_typesense/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/jaeyson/open_api_typesense/actions/workflows/ci.yml)
 
@@ -18,7 +18,7 @@ by adding `open_api_typesense` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:open_api_typesense, "~> 0.5"}
+    {:open_api_typesense, "~> 0.6"}
 
     # Or from GitHub repository, if you want the latest greatest from main branch
     {:open_api_typesense, git: "https://github.com/jaeyson/open_api_typesense.git"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   typesense:
-    image: docker.io/typesense/typesense:26.0
+    image: docker.io/typesense/typesense:27.1
     container_name: typesense
     restart: on-failure
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   typesense:
-    image: docker.io/typesense/typesense:27.1
+    image: docker.io/typesense/typesense:26.0
     container_name: typesense
     restart: on-failure
     ports:

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule OpenApiTypesense.MixProject do
 
   @source_url "https://github.com/jaeyson/open_api_typesense"
   @hex_url "https://hexdocs.pm/open_api_typesense"
-  @version "0.5.2"
+  @version "0.6.0"
 
   def project do
     [

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -74,7 +74,7 @@ defmodule ClientTest do
     end)
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "returns the configured options" do
     Application.put_env(:open_api_typesense, :options,
       finch: MyApp.CustomFinch,
@@ -86,7 +86,7 @@ defmodule ClientTest do
     assert options === [finch: MyApp.CustomFinch, receive_timeout: 5_000]
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "returns an empty map if options is not configured" do
     Application.delete_env(:open_api_typesense, :options)
 
@@ -95,7 +95,7 @@ defmodule ClientTest do
     assert options === nil
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "use another HTTP client" do
     map_conn = %{
       api_key: "xyz",

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -4,7 +4,7 @@ defmodule ConnectionTest do
 
   alias OpenApiTypesense.Connection
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "new/0 using the default config to creates a connection struct" do
     assert Connection.new() === %Connection{
              api_key: "xyz",
@@ -14,7 +14,7 @@ defmodule ConnectionTest do
            }
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "new/1 with custom fields creates a connection struct" do
     conn =
       Connection.new(%{
@@ -32,20 +32,20 @@ defmodule ConnectionTest do
            }
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "new/1 with Connection struct" do
     conn = Connection.new()
     assert %Connection{} = Connection.new(conn)
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "new/1 with empty map raises ArgumentError" do
     error = assert_raise ArgumentError, fn -> Connection.new(%{}) end
 
     assert error.message === "Missing required fields: [:api_key, :host, :port, :scheme]"
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "new/1 with invalid data type raises ArgumentError" do
     invalid_inputs = [
       nil,

--- a/test/operations/analytics_test.exs
+++ b/test/operations/analytics_test.exs
@@ -78,7 +78,7 @@ defmodule AnalyticsTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: create analytics rule with non-existent collection", %{
     conn: conn,
     map_conn: map_conn
@@ -114,7 +114,7 @@ defmodule AnalyticsTest do
              Analytics.create_analytics_rule(map_conn, body, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": false]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: upsert analytics rule", %{conn: conn, map_conn: map_conn} do
     name = "product_no_hits"
 
@@ -151,7 +151,7 @@ defmodule AnalyticsTest do
              Analytics.upsert_analytics_rule(map_conn, name, body, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: create analytics rule with wrong field" do
     name = "products_test_query"
     field_name = "wrong_field"
@@ -177,7 +177,7 @@ defmodule AnalyticsTest do
     assert {:error, %ApiResponse{message: _}} = Analytics.create_analytics_rule(body)
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: list analytics rules", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %AnalyticsRulesRetrieveSchema{rules: rules}} =
              Analytics.retrieve_analytics_rules()
@@ -200,7 +200,7 @@ defmodule AnalyticsTest do
              Analytics.retrieve_analytics_rules(map_conn, [])
   end
 
-  @tag ["27.1": true, "26.0": false, "0.25.2": false]
+  @tag ["27.1": true, "27.0": true, "26.0": false]
   test "success (v27.1): create analytics rule and event", %{conn: conn, map_conn: map_conn} do
     name = "product_popularity"
 

--- a/test/operations/collections_test.exs
+++ b/test/operations/collections_test.exs
@@ -32,7 +32,7 @@ defmodule CollectionsTest do
     %{schema: schema, alias_name: "foo_bar", conn: conn, map_conn: map_conn}
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: clone a collection schema" do
     schema = %{
       "name" => "vehicles",
@@ -58,7 +58,7 @@ defmodule CollectionsTest do
              Collections.create_collection(payload, src_name: schema["name"])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: create a collection", %{schema: schema, conn: conn, map_conn: map_conn} do
     name = schema["name"]
 
@@ -72,7 +72,7 @@ defmodule CollectionsTest do
              Collections.create_collection(map_conn, schema, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: list collections", %{conn: conn, map_conn: map_conn} do
     assert {:ok, collections} = Collections.get_collections()
     assert length(collections) >= 0
@@ -85,7 +85,7 @@ defmodule CollectionsTest do
     assert {:ok, _} = Collections.get_collections(map_conn, limit: 1)
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: update an existing collection", %{conn: conn, map_conn: map_conn} do
     name = "burgers"
 
@@ -122,7 +122,7 @@ defmodule CollectionsTest do
     Collections.delete_collection(name)
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: list empty aliases", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %CollectionAliasesResponse{aliases: aliases}} = Collections.get_aliases()
     assert length(aliases) >= 0
@@ -133,7 +133,7 @@ defmodule CollectionsTest do
     assert {:ok, _} = Collections.get_aliases(map_conn, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: delete a missing collection", %{conn: conn, map_conn: map_conn} do
     assert Collections.delete_collection("non-existing-collection") ==
              {:error,
@@ -148,7 +148,7 @@ defmodule CollectionsTest do
     assert {:error, %ApiResponse{message: _}} = Collections.delete_collection(map_conn, "xyz", [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: upsert an alias", %{
     schema: schema,
     alias_name: alias_name,
@@ -176,7 +176,7 @@ defmodule CollectionsTest do
     assert {:error, %ApiResponse{message: _}} = Collections.delete_alias(map_conn, alias_name, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: get a non-existing alias", %{conn: conn, map_conn: map_conn} do
     assert Collections.get_alias("non-existing-alias") ==
              {:error, %ApiResponse{message: "Not Found"}}
@@ -188,7 +188,7 @@ defmodule CollectionsTest do
     assert {:error, %ApiResponse{message: _}} = Collections.get_alias(map_conn, "xyz", [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: get a non-existing collection", %{conn: conn, map_conn: map_conn} do
     assert Collections.get_collection("non-existing-collection") ==
              {:error, %ApiResponse{message: "Not Found"}}

--- a/test/operations/conversations_test.exs
+++ b/test/operations/conversations_test.exs
@@ -34,7 +34,7 @@ defmodule ConversationsTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": false]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: list conversation models", %{conn: conn, map_conn: map_conn} do
     assert {:ok, models} = Conversations.retrieve_all_conversation_models()
     assert length(models) >= 0
@@ -45,7 +45,7 @@ defmodule ConversationsTest do
     assert {:ok, _} = Conversations.retrieve_all_conversation_models(map_conn, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": false]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: get a non-existent conversation model", %{conn: conn, map_conn: map_conn} do
     assert {:error, %ApiResponse{message: "Model not found"}} =
              Conversations.retrieve_conversation_model("non-existent")
@@ -57,7 +57,7 @@ defmodule ConversationsTest do
     assert {:error, _} = Conversations.retrieve_conversation_model(map_conn, "xyz", [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": false]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: delete a conversation model", %{conn: conn, map_conn: map_conn} do
     assert {:error, %ApiResponse{message: "Model not found"}} =
              Conversations.delete_conversation_model("non-existent")
@@ -69,7 +69,7 @@ defmodule ConversationsTest do
     assert {:error, _} = Conversations.delete_conversation_model(map_conn, "xyz", [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": false]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: create a conversation model with incorrect API key", %{
     conn: conn,
     map_conn: map_conn
@@ -102,7 +102,7 @@ defmodule ConversationsTest do
     assert {:error, _} = Conversations.create_conversation_model(map_conn, body, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": false]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: update a conversation model with incorrect API key", %{
     conn: conn,
     map_conn: map_conn

--- a/test/operations/curation_test.exs
+++ b/test/operations/curation_test.exs
@@ -34,7 +34,7 @@ defmodule CurationTest do
     %{schema_name: name, conn: conn, map_conn: map_conn}
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: upsert search override", %{
     schema_name: schema_name,
     conn: conn,
@@ -69,7 +69,7 @@ defmodule CurationTest do
              Curation.upsert_search_override(map_conn, schema_name, override_id, body, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: delete search override", %{
     schema_name: schema_name,
     conn: conn,
@@ -87,7 +87,7 @@ defmodule CurationTest do
     assert {:error, _} = Curation.delete_search_override(map_conn, schema_name, "test", [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: list collection overrides", %{
     schema_name: schema_name,
     conn: conn,

--- a/test/operations/debug_test.exs
+++ b/test/operations/debug_test.exs
@@ -12,7 +12,7 @@ defmodule DebugTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: list stopwords sets", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %Debug{version: _}} = Debug.debug()
     assert {:ok, _} = Debug.debug([])
@@ -22,7 +22,7 @@ defmodule DebugTest do
     assert {:ok, _} = Debug.debug(map_conn, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "field" do
     assert [version: {:string, :generic}] = Debug.__fields__(:debug_200_json_resp)
   end

--- a/test/operations/documents_test.exs
+++ b/test/operations/documents_test.exs
@@ -38,7 +38,7 @@ defmodule DocumentsTest do
     %{coll_name: name, conn: conn, map_conn: map_conn}
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: update a non-existent document", %{
     coll_name: coll_name,
     conn: conn,
@@ -64,7 +64,7 @@ defmodule DocumentsTest do
     assert {:error, _} = Documents.update_document(map_conn, coll_name, document_id, body, opts)
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: search a document", %{coll_name: coll_name, conn: conn, map_conn: map_conn} do
     body =
       [
@@ -107,7 +107,7 @@ defmodule DocumentsTest do
     assert {:ok, _} = Documents.search(map_conn, coll_name, opts)
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: update non-existent documents", %{
     coll_name: coll_name,
     conn: conn,
@@ -131,7 +131,7 @@ defmodule DocumentsTest do
     assert {:ok, _} = Documents.import_documents(map_conn, coll_name, body, opts)
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: multi-search with no documents", %{conn: conn, map_conn: map_conn} do
     body =
       %{
@@ -156,7 +156,7 @@ defmodule DocumentsTest do
     assert {:ok, _} = Documents.multi_search(map_conn, body, params)
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: update documents by query", %{
     coll_name: coll_name,
     conn: conn,
@@ -211,7 +211,7 @@ defmodule DocumentsTest do
              Documents.update_documents(map_conn, coll_name, update, filter_by: "shoes_id:>=0")
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: import documents", %{coll_name: coll_name} do
     body =
       [
@@ -246,7 +246,7 @@ defmodule DocumentsTest do
     assert {:ok, _} = Documents.import_documents(coll_name, body, action: "create")
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: index a document", %{coll_name: coll_name, conn: conn, map_conn: map_conn} do
     shoes_id = 220
 
@@ -272,7 +272,7 @@ defmodule DocumentsTest do
     assert {:ok, _} = Documents.index_document(map_conn, coll_name, body, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: list collection overrides", %{
     coll_name: coll_name,
     conn: conn,
@@ -293,7 +293,7 @@ defmodule DocumentsTest do
     assert {:error, _} = Documents.get_search_overrides(map_conn, "xyz", [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: get a non-existent override", %{
     coll_name: coll_name,
     conn: conn,
@@ -309,7 +309,7 @@ defmodule DocumentsTest do
     assert {:error, _} = Documents.get_search_override(map_conn, coll_name, "xyz", [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: delete a non-existent override", %{
     coll_name: coll_name,
     conn: conn,
@@ -325,7 +325,7 @@ defmodule DocumentsTest do
     assert {:error, _} = Documents.delete_search_override(map_conn, coll_name, "xyz", [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: delete a document", %{coll_name: coll_name, conn: conn, map_conn: map_conn} do
     shoes_id = 420
 
@@ -359,7 +359,7 @@ defmodule DocumentsTest do
     assert {:error, _} = Documents.delete_document(map_conn, coll_name, id, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: delete all documents", %{coll_name: coll_name, conn: conn, map_conn: map_conn} do
     body =
       [
@@ -403,7 +403,7 @@ defmodule DocumentsTest do
     assert {:ok, _} = Documents.delete_documents(map_conn, coll_name, opts)
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: get a non-existent document", %{
     coll_name: coll_name,
     conn: conn,
@@ -422,7 +422,7 @@ defmodule DocumentsTest do
     assert {:error, _} = Documents.get_document(map_conn, coll_name, document_id, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: export document from a non-existent collection", %{conn: conn, map_conn: map_conn} do
     opts = [exclude_fields: "fields"]
 
@@ -436,7 +436,7 @@ defmodule DocumentsTest do
     assert {:error, _} = Documents.export_documents(map_conn, "xyz", opts)
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: upsert a search override", %{
     coll_name: coll_name,
     conn: conn,
@@ -473,7 +473,7 @@ defmodule DocumentsTest do
              Documents.upsert_search_override(map_conn, coll_name, "customize-apple", body, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "field" do
     assert [num_deleted: :integer] = Documents.__fields__(:delete_documents_200_json_resp)
     assert [num_updated: :integer] = Documents.__fields__(:update_documents_200_json_resp)

--- a/test/operations/health_test.exs
+++ b/test/operations/health_test.exs
@@ -12,7 +12,7 @@ defmodule HealthTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: health check", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %HealthStatus{ok: true}} = Health.health()
     assert {:ok, %HealthStatus{ok: true}} = Health.health([])
@@ -22,7 +22,7 @@ defmodule HealthTest do
     assert {:ok, %HealthStatus{ok: true}} = Health.health(map_conn, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: health check timeout" do
     conn =
       Connection.new(%{
@@ -35,7 +35,7 @@ defmodule HealthTest do
     assert {:error, "timeout"} = Health.health(conn, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: health check connection refused" do
     conn =
       Connection.new(%{
@@ -48,7 +48,7 @@ defmodule HealthTest do
     assert {:error, "connection refused"} = Health.health(conn, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: health check non-existing domain" do
     conn = %{
       api_key: "wrong_key",

--- a/test/operations/keys_test.exs
+++ b/test/operations/keys_test.exs
@@ -29,7 +29,7 @@ defmodule KeysTest do
     %{api_key_schema: api_key_schema, conn: conn, map_conn: map_conn}
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: get a specific key", %{
     api_key_schema: api_key_schema,
     conn: conn,
@@ -47,7 +47,7 @@ defmodule KeysTest do
     assert {:ok, %ApiKey{id: ^key_id}} = Keys.get_key(map_conn, key_id, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: list API keys", %{conn: conn, map_conn: map_conn} do
     {:ok, %ApiKeysResponse{keys: keys}} = Keys.get_keys()
     assert length(keys) >= 0
@@ -59,7 +59,7 @@ defmodule KeysTest do
     {:ok, %ApiKeysResponse{}} = Keys.get_keys(map_conn, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: delete an API key", %{
     api_key_schema: api_key_schema,
     conn: conn,
@@ -77,7 +77,7 @@ defmodule KeysTest do
     assert {:error, _} = Keys.delete_key(map_conn, key_id, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: create an search-only API key", %{
     api_key_schema: api_key_schema,
     conn: conn,
@@ -91,7 +91,7 @@ defmodule KeysTest do
     assert {:ok, %ApiKey{}} = Keys.create_key(map_conn, api_key_schema, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: create an admin API key", %{api_key_schema: api_key_schema} do
     body =
       api_key_schema

--- a/test/operations/operations_test.exs
+++ b/test/operations/operations_test.exs
@@ -15,7 +15,7 @@ defmodule OperationsTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: retrieve api stats", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %APIStatsResponse{}} = Operations.retrieve_api_stats()
     assert {:ok, %APIStatsResponse{}} = Operations.retrieve_api_stats([])
@@ -25,7 +25,7 @@ defmodule OperationsTest do
     assert {:ok, %APIStatsResponse{}} = Operations.retrieve_api_stats(map_conn, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: retrieve metrics", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %{system_cpu_active_percentage: _}} = Operations.retrieve_metrics()
     assert {:ok, %{system_cpu_active_percentage: _}} = Operations.retrieve_metrics([])
@@ -35,7 +35,7 @@ defmodule OperationsTest do
     assert {:ok, %{system_cpu_active_percentage: _}} = Operations.retrieve_metrics(map_conn, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: toggle threshold time for request log", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %SuccessStatus{success: true}} =
              Operations.config(%{"log_slow_requests_time_ms" => 2_000})
@@ -48,7 +48,7 @@ defmodule OperationsTest do
     assert {:ok, %SuccessStatus{success: true}} = Operations.config(map_conn, body, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: clear cache", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %SuccessStatus{success: true}} = Operations.clear_cache()
     assert {:ok, %SuccessStatus{success: true}} = Operations.clear_cache([])
@@ -58,7 +58,7 @@ defmodule OperationsTest do
     assert {:ok, %SuccessStatus{success: true}} = Operations.clear_cache(map_conn, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: compact database", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %SuccessStatus{success: true}} = Operations.compact()
     assert {:ok, %SuccessStatus{success: true}} = Operations.compact([])
@@ -68,7 +68,7 @@ defmodule OperationsTest do
     assert {:ok, %SuccessStatus{success: true}} = Operations.compact(map_conn, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: take snapshot", %{conn: conn, map_conn: map_conn} do
     params = [snapshot_path: "/tmp/typesense-data-snapshot"]
 
@@ -81,7 +81,7 @@ defmodule OperationsTest do
     assert {:ok, %SuccessStatus{success: true}} = Operations.take_snapshot(map_conn, params)
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: re-elect leader", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %SuccessStatus{success: false}} = Operations.vote()
     assert {:ok, %SuccessStatus{success: false}} = Operations.vote([])

--- a/test/operations/override_test.exs
+++ b/test/operations/override_test.exs
@@ -12,7 +12,7 @@ defmodule OverrideTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "error: retrieve an override", %{conn: conn, map_conn: map_conn} do
     assert {:error, %ApiResponse{message: "Not Found"}} =
              Override.get_search_override("helmets", "custom-helmet")

--- a/test/operations/presets_test.exs
+++ b/test/operations/presets_test.exs
@@ -33,7 +33,7 @@ defmodule PresetsTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: list presets", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %PresetsRetrieveSchema{presets: presets}} = Presets.retrieve_all_presets()
     assert length(presets) >= 1
@@ -45,7 +45,7 @@ defmodule PresetsTest do
     assert {:ok, _} = Presets.retrieve_all_presets(map_conn, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: get a preset", %{conn: conn, map_conn: map_conn} do
     assert {:error, %ApiResponse{message: "Not found."}} = Presets.retrieve_preset("listing_view")
     assert {:error, _} = Presets.retrieve_preset("listing_view", [])
@@ -55,7 +55,7 @@ defmodule PresetsTest do
     assert {:error, _} = Presets.retrieve_preset(map_conn, "listing_view", [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: upsert a preset", %{conn: conn, map_conn: map_conn} do
     body =
       %{
@@ -76,7 +76,7 @@ defmodule PresetsTest do
     assert {:ok, _} = Presets.upsert_preset(map_conn, "restaurant_view", body, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: delete a preset", %{conn: conn, map_conn: map_conn} do
     body =
       %{

--- a/test/operations/stopwords_test.exs
+++ b/test/operations/stopwords_test.exs
@@ -24,7 +24,7 @@ defmodule StopwordsTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": false]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: list stopwords sets", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %StopwordsSetsRetrieveAllSchema{stopwords: stopwords}} =
              Stopwords.retrieve_stopwords_sets()
@@ -37,7 +37,7 @@ defmodule StopwordsTest do
     assert {:ok, _} = Stopwords.retrieve_stopwords_sets(map_conn, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": false]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: add stopwords", %{conn: conn, map_conn: map_conn} do
     set_id = "stopword_set_countries"
 
@@ -55,7 +55,7 @@ defmodule StopwordsTest do
     assert {:ok, _} = Stopwords.upsert_stopwords_set(map_conn, set_id, body, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": false]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: retrieve specific stopwords set", %{conn: conn, map_conn: map_conn} do
     set_id = "stopword_set_names"
 
@@ -77,7 +77,7 @@ defmodule StopwordsTest do
     assert {:ok, _} = Stopwords.retrieve_stopwords_set(map_conn, set_id, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": false]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: delete specific stopwords set", %{conn: conn, map_conn: map_conn} do
     set_id = "stopword_set_companies"
 
@@ -96,7 +96,7 @@ defmodule StopwordsTest do
     assert {:error, _} = Stopwords.delete_stopwords_set(map_conn, set_id, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": false]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "field" do
     assert [id: {:string, :generic}] = Stopwords.__fields__(:delete_stopwords_set_200_json_resp)
   end

--- a/test/operations/synonyms_test.exs
+++ b/test/operations/synonyms_test.exs
@@ -32,7 +32,7 @@ defmodule SynonymsTest do
     %{coll_name: collection_name, conn: conn, map_conn: map_conn}
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: list collection synonyms", %{
     coll_name: coll_name,
     conn: conn,
@@ -50,7 +50,7 @@ defmodule SynonymsTest do
     assert {:ok, _} = Synonyms.get_search_synonyms(map_conn, coll_name, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: upsert a collection synonym", %{
     coll_name: coll_name,
     conn: conn,
@@ -74,7 +74,7 @@ defmodule SynonymsTest do
     assert {:ok, _} = Synonyms.upsert_search_synonym(map_conn, coll_name, synonym_id, body, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: delete a collection synonym", %{
     coll_name: coll_name,
     conn: conn,
@@ -99,7 +99,7 @@ defmodule SynonymsTest do
     assert {:error, _} = Synonyms.delete_search_synonym(map_conn, coll_name, synonym_id, [])
   end
 
-  @tag ["27.1": true, "26.0": true, "0.25.2": true]
+  @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: get a collection synonym", %{
     coll_name: coll_name,
     conn: conn,


### PR DESCRIPTION
Updates #13

## Summary by Sourcery

Drop support for Typesense v0.25.2 and add support for v27.0.

CI:
- Update CI to test against Typesense v26.0, v27.0, and v27.1.

Tests:
- Update test tags to reflect the supported Typesense versions.