### PR TITLE
Add 401 for unauthorized access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## major.minor.patch (yyyy.mm.dd)
 
+## 0.6.1 (2025.01.19)
+
+### Added
+
+* `401` status code for unauthorized access
+
 ## 0.6.0 (2025.01.19)
 
 ### Changed

--- a/lib/open_api_typesense/operations/analytics.ex
+++ b/lib/open_api_typesense/operations/analytics.ex
@@ -60,7 +60,8 @@ defmodule OpenApiTypesense.Analytics do
       request: [{"application/json", {OpenApiTypesense.AnalyticsEventCreateSchema, :t}}],
       response: [
         {201, {OpenApiTypesense.AnalyticsEventCreateResponse, :t}},
-        {400, {OpenApiTypesense.ApiResponse, :t}}
+        {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
     })
@@ -120,6 +121,7 @@ defmodule OpenApiTypesense.Analytics do
       response: [
         {201, {OpenApiTypesense.AnalyticsRuleSchema, :t}},
         {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -177,6 +179,7 @@ defmodule OpenApiTypesense.Analytics do
       method: :delete,
       response: [
         {200, {OpenApiTypesense.AnalyticsRuleDeleteResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -234,6 +237,7 @@ defmodule OpenApiTypesense.Analytics do
       method: :get,
       response: [
         {200, {OpenApiTypesense.AnalyticsRuleSchema, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -247,7 +251,8 @@ defmodule OpenApiTypesense.Analytics do
 
   """
   @spec retrieve_analytics_rules ::
-          {:ok, OpenApiTypesense.AnalyticsRulesRetrieveSchema.t()} | :error
+          {:ok, OpenApiTypesense.AnalyticsRulesRetrieveSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_analytics_rules do
     retrieve_analytics_rules(Connection.new())
   end
@@ -259,7 +264,8 @@ defmodule OpenApiTypesense.Analytics do
   - `retrieve_analytics_rules(Connection.new())`
   """
   @spec retrieve_analytics_rules(map() | Connection.t() | keyword()) ::
-          {:ok, OpenApiTypesense.AnalyticsRulesRetrieveSchema.t()} | :error
+          {:ok, OpenApiTypesense.AnalyticsRulesRetrieveSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_analytics_rules(opts) when is_list(opts) do
     retrieve_analytics_rules(Connection.new(), opts)
   end
@@ -274,7 +280,8 @@ defmodule OpenApiTypesense.Analytics do
   - `retrieve_analytics_rules(Connection.new(), opts)`
   """
   @spec retrieve_analytics_rules(map() | Connection.t(), keyword()) ::
-          {:ok, OpenApiTypesense.AnalyticsRulesRetrieveSchema.t()} | :error
+          {:ok, OpenApiTypesense.AnalyticsRulesRetrieveSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_analytics_rules(conn, opts) when not is_struct(conn) and is_map(conn) do
     retrieve_analytics_rules(Connection.new(conn), opts)
   end
@@ -287,7 +294,10 @@ defmodule OpenApiTypesense.Analytics do
       call: {OpenApiTypesense.Analytics, :retrieve_analytics_rules},
       url: "/analytics/rules",
       method: :get,
-      response: [{200, {OpenApiTypesense.AnalyticsRulesRetrieveSchema, :t}}],
+      response: [
+        {200, {OpenApiTypesense.AnalyticsRulesRetrieveSchema, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end
@@ -350,7 +360,8 @@ defmodule OpenApiTypesense.Analytics do
       request: [{"application/json", {OpenApiTypesense.AnalyticsRuleUpsertSchema, :t}}],
       response: [
         {200, {OpenApiTypesense.AnalyticsRuleSchema, :t}},
-        {400, {OpenApiTypesense.ApiResponse, :t}}
+        {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
     })

--- a/lib/open_api_typesense/operations/collections.ex
+++ b/lib/open_api_typesense/operations/collections.ex
@@ -80,6 +80,7 @@ defmodule OpenApiTypesense.Collections do
       response: [
         {201, {OpenApiTypesense.CollectionResponse, :t}},
         {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {409, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -132,6 +133,7 @@ defmodule OpenApiTypesense.Collections do
       method: :delete,
       response: [
         {200, {OpenApiTypesense.CollectionAlias, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -189,6 +191,7 @@ defmodule OpenApiTypesense.Collections do
       method: :delete,
       response: [
         {200, {OpenApiTypesense.CollectionResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -243,6 +246,7 @@ defmodule OpenApiTypesense.Collections do
       method: :get,
       response: [
         {200, {OpenApiTypesense.CollectionAlias, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -254,7 +258,9 @@ defmodule OpenApiTypesense.Collections do
 
   List all aliases and the corresponding collections that they map to.
   """
-  @spec get_aliases :: {:ok, OpenApiTypesense.CollectionAliasesResponse.t()} | :error
+  @spec get_aliases ::
+          {:ok, OpenApiTypesense.CollectionAliasesResponse.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_aliases do
     get_aliases(Connection.new())
   end
@@ -266,7 +272,8 @@ defmodule OpenApiTypesense.Collections do
   - `get_aliases(Connection.new())`
   """
   @spec get_aliases(map() | Connection.t() | keyword()) ::
-          {:ok, OpenApiTypesense.CollectionAliasesResponse.t()} | :error
+          {:ok, OpenApiTypesense.CollectionAliasesResponse.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_aliases(opts) when is_list(opts) do
     get_aliases(Connection.new(), opts)
   end
@@ -281,7 +288,8 @@ defmodule OpenApiTypesense.Collections do
   - `get_aliases(Connection.new(), opts)`
   """
   @spec get_aliases(map() | Connection.t(), keyword()) ::
-          {:ok, OpenApiTypesense.CollectionAliasesResponse.t()} | :error
+          {:ok, OpenApiTypesense.CollectionAliasesResponse.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_aliases(conn, opts) when not is_struct(conn) and is_map(conn) do
     get_aliases(Connection.new(conn), opts)
   end
@@ -294,7 +302,10 @@ defmodule OpenApiTypesense.Collections do
       call: {OpenApiTypesense.Collections, :get_aliases},
       url: "/aliases",
       method: :get,
-      response: [{200, {OpenApiTypesense.CollectionAliasesResponse, :t}}],
+      response: [
+        {200, {OpenApiTypesense.CollectionAliasesResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end
@@ -350,6 +361,7 @@ defmodule OpenApiTypesense.Collections do
       method: :get,
       response: [
         {200, {OpenApiTypesense.CollectionResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -368,7 +380,9 @@ defmodule OpenApiTypesense.Collections do
     * `exclude_fields`: Exclude the field definitions from being returned in the response.
 
   """
-  @spec get_collections :: {:ok, [OpenApiTypesense.CollectionResponse.t()]} | :error
+  @spec get_collections ::
+          {:ok, [OpenApiTypesense.CollectionResponse.t()]}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_collections, do: get_collections(Connection.new())
 
   @doc """
@@ -378,7 +392,8 @@ defmodule OpenApiTypesense.Collections do
   - `get_collections(exclude_fields: "fields", limit: 10)`
   """
   @spec get_collections(map() | Connection.t() | keyword()) ::
-          {:ok, [OpenApiTypesense.CollectionResponse.t()]} | :error
+          {:ok, [OpenApiTypesense.CollectionResponse.t()]}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_collections(opts) when is_list(opts) do
     get_collections(Connection.new(), opts)
   end
@@ -393,7 +408,8 @@ defmodule OpenApiTypesense.Collections do
   - `get_collections(Connection.new(), opts)`
   """
   @spec get_collections(map() | Connection.t(), keyword()) ::
-          {:ok, [OpenApiTypesense.CollectionResponse.t()]} | :error
+          {:ok, [OpenApiTypesense.CollectionResponse.t()]}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_collections(conn, opts) when not is_struct(conn) do
     get_collections(Connection.new(conn), opts)
   end
@@ -408,7 +424,10 @@ defmodule OpenApiTypesense.Collections do
       url: "/collections",
       method: :get,
       query: query,
-      response: [{200, [{OpenApiTypesense.CollectionResponse, :t}]}],
+      response: [
+        {200, [{OpenApiTypesense.CollectionResponse, :t}]},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end
@@ -469,6 +488,7 @@ defmodule OpenApiTypesense.Collections do
       response: [
         {200, {OpenApiTypesense.CollectionUpdateSchema, :t}},
         {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -531,6 +551,7 @@ defmodule OpenApiTypesense.Collections do
       response: [
         {200, {OpenApiTypesense.CollectionAlias, :t}},
         {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts

--- a/lib/open_api_typesense/operations/conversations.ex
+++ b/lib/open_api_typesense/operations/conversations.ex
@@ -60,7 +60,8 @@ defmodule OpenApiTypesense.Conversations do
       request: [{"application/json", {OpenApiTypesense.ConversationModelCreateSchema, :t}}],
       response: [
         {200, {OpenApiTypesense.ConversationModelSchema, :t}},
-        {400, {OpenApiTypesense.ApiResponse, :t}}
+        {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
     })
@@ -72,7 +73,8 @@ defmodule OpenApiTypesense.Conversations do
   Delete a conversation model
   """
   @spec delete_conversation_model(String.t()) ::
-          {:ok, OpenApiTypesense.ConversationModelSchema.t()} | :error
+          {:ok, OpenApiTypesense.ConversationModelSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def delete_conversation_model(modelId) do
     delete_conversation_model(Connection.new(), modelId)
   end
@@ -84,7 +86,8 @@ defmodule OpenApiTypesense.Conversations do
   - `delete_conversation_model(Connection.new(), modelId)`
   """
   @spec delete_conversation_model(map() | Connection.t(), String.t(), String.t() | keyword()) ::
-          {:ok, OpenApiTypesense.ConversationModelSchema.t()} | :error
+          {:ok, OpenApiTypesense.ConversationModelSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def delete_conversation_model(modelId, opts) when is_list(opts) and is_binary(modelId) do
     delete_conversation_model(Connection.new(), modelId, opts)
   end
@@ -99,7 +102,8 @@ defmodule OpenApiTypesense.Conversations do
   - `delete_conversation_model(Connection.new(), modelId, opts)`
   """
   @spec delete_conversation_model(map() | Connection.t(), String.t(), keyword()) ::
-          {:ok, OpenApiTypesense.ConversationModelSchema.t()} | :error
+          {:ok, OpenApiTypesense.ConversationModelSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def delete_conversation_model(conn, modelId, opts) when not is_struct(conn) and is_map(conn) do
     delete_conversation_model(Connection.new(conn), modelId, opts)
   end
@@ -114,6 +118,7 @@ defmodule OpenApiTypesense.Conversations do
       method: :delete,
       response: [
         {200, {OpenApiTypesense.ConversationModelSchema, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -126,7 +131,8 @@ defmodule OpenApiTypesense.Conversations do
   Retrieve all conversation models
   """
   @spec retrieve_all_conversation_models ::
-          {:ok, [OpenApiTypesense.ConversationModelSchema.t()]} | :error
+          {:ok, [OpenApiTypesense.ConversationModelSchema.t()]}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_all_conversation_models do
     retrieve_all_conversation_models(Connection.new())
   end
@@ -138,7 +144,8 @@ defmodule OpenApiTypesense.Conversations do
   - `retrieve_all_conversation_models(Connection.new())`
   """
   @spec retrieve_all_conversation_models(map() | Connection.t() | keyword()) ::
-          {:ok, [OpenApiTypesense.ConversationModelSchema.t()]} | :error
+          {:ok, [OpenApiTypesense.ConversationModelSchema.t()]}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_all_conversation_models(opts) when is_list(opts) do
     retrieve_all_conversation_models(Connection.new(), opts)
   end
@@ -153,7 +160,8 @@ defmodule OpenApiTypesense.Conversations do
   - `retrieve_all_conversation_models(Connection.new(), opts)`
   """
   @spec retrieve_all_conversation_models(map() | Connection.t(), keyword()) ::
-          {:ok, [OpenApiTypesense.ConversationModelSchema.t()]} | :error
+          {:ok, [OpenApiTypesense.ConversationModelSchema.t()]}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_all_conversation_models(conn, opts) when not is_struct(conn) and is_map(conn) do
     retrieve_all_conversation_models(Connection.new(conn), opts)
   end
@@ -166,7 +174,10 @@ defmodule OpenApiTypesense.Conversations do
       call: {OpenApiTypesense.Conversations, :retrieve_all_conversation_models},
       url: "/conversations/models",
       method: :get,
-      response: [{200, [{OpenApiTypesense.ConversationModelSchema, :t}]}],
+      response: [
+        {200, [{OpenApiTypesense.ConversationModelSchema, :t}]},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end
@@ -177,7 +188,8 @@ defmodule OpenApiTypesense.Conversations do
   Retrieve a conversation model
   """
   @spec retrieve_conversation_model(String.t()) ::
-          {:ok, OpenApiTypesense.ConversationModelSchema.t()} | :error
+          {:ok, OpenApiTypesense.ConversationModelSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_conversation_model(modelId) do
     retrieve_conversation_model(Connection.new(), modelId)
   end
@@ -189,7 +201,8 @@ defmodule OpenApiTypesense.Conversations do
   - `retrieve_conversation_model(Connection.new(), modelId)`
   """
   @spec retrieve_conversation_model(map() | Connection.t() | String.t(), String.t() | keyword()) ::
-          {:ok, OpenApiTypesense.ConversationModelSchema.t()} | :error
+          {:ok, OpenApiTypesense.ConversationModelSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_conversation_model(modelId, opts) when is_list(opts) and is_binary(modelId) do
     retrieve_conversation_model(Connection.new(), modelId, opts)
   end
@@ -204,7 +217,8 @@ defmodule OpenApiTypesense.Conversations do
   - `retrieve_conversation_model(Connection.new(), modelId, opts)`
   """
   @spec retrieve_conversation_model(map() | Connection.t(), String.t(), keyword()) ::
-          {:ok, OpenApiTypesense.ConversationModelSchema.t()} | :error
+          {:ok, OpenApiTypesense.ConversationModelSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_conversation_model(conn, modelId, opts)
       when not is_struct(conn) and is_map(conn) do
     retrieve_conversation_model(Connection.new(conn), modelId, opts)
@@ -220,6 +234,7 @@ defmodule OpenApiTypesense.Conversations do
       method: :get,
       response: [
         {200, {OpenApiTypesense.ConversationModelSchema, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -232,7 +247,8 @@ defmodule OpenApiTypesense.Conversations do
   Update a conversation model
   """
   @spec update_conversation_model(String.t(), map()) ::
-          {:ok, OpenApiTypesense.ConversationModelSchema.t()} | :error
+          {:ok, OpenApiTypesense.ConversationModelSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def update_conversation_model(modelId, body) do
     update_conversation_model(Connection.new(), modelId, body)
   end
@@ -247,7 +263,9 @@ defmodule OpenApiTypesense.Conversations do
           map() | Connection.t() | String.t(),
           String.t() | map(),
           map() | keyword()
-        ) :: {:ok, OpenApiTypesense.ConversationModelSchema.t()} | :error
+        ) ::
+          {:ok, OpenApiTypesense.ConversationModelSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def update_conversation_model(modelId, body, opts) when is_list(opts) and is_binary(modelId) do
     update_conversation_model(Connection.new(), modelId, body, opts)
   end
@@ -262,7 +280,8 @@ defmodule OpenApiTypesense.Conversations do
   - `update_conversation_model(Connection.new(), modelId, body, opts)`
   """
   @spec update_conversation_model(map() | Connection.t(), String.t(), map(), keyword()) ::
-          {:ok, OpenApiTypesense.ConversationModelSchema.t()} | :error
+          {:ok, OpenApiTypesense.ConversationModelSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def update_conversation_model(conn, modelId, body, opts)
       when not is_struct(conn) and is_map(conn) do
     update_conversation_model(Connection.new(conn), modelId, body, opts)
@@ -280,6 +299,7 @@ defmodule OpenApiTypesense.Conversations do
       request: [{"application/json", {OpenApiTypesense.ConversationModelUpdateSchema, :t}}],
       response: [
         {200, {OpenApiTypesense.ConversationModelSchema, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts

--- a/lib/open_api_typesense/operations/curation.ex
+++ b/lib/open_api_typesense/operations/curation.ex
@@ -63,6 +63,7 @@ defmodule OpenApiTypesense.Curation do
       method: :delete,
       response: [
         {200, {OpenApiTypesense.SearchOverrideDeleteResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -79,7 +80,8 @@ defmodule OpenApiTypesense.Curation do
 
   """
   @spec get_search_overrides(String.t()) ::
-          {:ok, OpenApiTypesense.SearchOverridesResponse.t()} | :error
+          {:ok, OpenApiTypesense.SearchOverridesResponse.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_search_overrides(collectionName) do
     get_search_overrides(Connection.new(), collectionName)
   end
@@ -91,7 +93,8 @@ defmodule OpenApiTypesense.Curation do
   - `get_search_overrides(Connection.new(), collectionName)`
   """
   @spec get_search_overrides(map() | Connection.t() | String.t(), String.t() | keyword()) ::
-          {:ok, OpenApiTypesense.SearchOverridesResponse.t()} | :error
+          {:ok, OpenApiTypesense.SearchOverridesResponse.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_search_overrides(collectionName, opts)
       when is_list(opts) and is_binary(collectionName) do
     get_search_overrides(Connection.new(), collectionName, opts)
@@ -107,7 +110,8 @@ defmodule OpenApiTypesense.Curation do
   - `get_search_overrides(Connection.new(), collectionName, opts)`
   """
   @spec get_search_overrides(map() | Connection.t(), String.t(), keyword()) ::
-          {:ok, OpenApiTypesense.SearchOverridesResponse.t()} | :error
+          {:ok, OpenApiTypesense.SearchOverridesResponse.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_search_overrides(conn, collectionName, opts)
       when not is_struct(conn) and is_map(conn) do
     get_search_overrides(Connection.new(conn), collectionName, opts)
@@ -125,6 +129,7 @@ defmodule OpenApiTypesense.Curation do
       query: query,
       response: [
         {200, {OpenApiTypesense.SearchOverridesResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -189,6 +194,7 @@ defmodule OpenApiTypesense.Curation do
       request: [{"application/json", {OpenApiTypesense.SearchOverrideSchema, :t}}],
       response: [
         {200, {OpenApiTypesense.SearchOverride, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts

--- a/lib/open_api_typesense/operations/debug.ex
+++ b/lib/open_api_typesense/operations/debug.ex
@@ -16,7 +16,7 @@ defmodule OpenApiTypesense.Debug do
 
   Print debugging information
   """
-  @spec debug :: {:ok, map()} | :error
+  @spec debug :: {:ok, map()} | {:ok, map()} | {:error, OpenApiTypesense.ApiResponse.t()}
   def debug, do: debug(Connection.new())
 
   @doc """
@@ -25,7 +25,8 @@ defmodule OpenApiTypesense.Debug do
   - `debug(%{api_key: xyz, host: ...})`
   - `debug(Connection.new())`
   """
-  @spec debug(map() | Connection.t() | keyword()) :: {:ok, map()} | :error
+  @spec debug(map() | Connection.t() | keyword()) ::
+          {:ok, map()} | {:error, OpenApiTypesense.ApiResponse.t()}
   def debug(opts) when is_list(opts) do
     debug(Connection.new(), opts)
   end
@@ -39,7 +40,8 @@ defmodule OpenApiTypesense.Debug do
   - `debug(%{api_key: xyz, host: ...}, opts)`
   - `debug(Connection.new(), opts)`
   """
-  @spec debug(map() | Connection.t(), keyword()) :: {:ok, map()} | :error
+  @spec debug(map() | Connection.t(), keyword()) ::
+          {:ok, map()} | {:error, OpenApiTypesense.ApiResponse.t()}
   def debug(conn, opts) when not is_struct(conn) and is_map(conn) do
     debug(Connection.new(conn), opts)
   end
@@ -53,7 +55,10 @@ defmodule OpenApiTypesense.Debug do
       call: {OpenApiTypesense.Debug, :debug},
       url: "/debug",
       method: :get,
-      response: [{200, {OpenApiTypesense.Debug, :debug_200_json_resp}}],
+      response: [
+        {200, {OpenApiTypesense.Debug, :debug_200_json_resp}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end

--- a/lib/open_api_typesense/operations/documents.ex
+++ b/lib/open_api_typesense/operations/documents.ex
@@ -65,7 +65,11 @@ defmodule OpenApiTypesense.Documents do
       url: "/collections/#{collectionName}/documents/#{documentId}",
       method: :delete,
       query: query,
-      response: [{200, :map}, {404, {OpenApiTypesense.ApiResponse, :t}}],
+      response: [
+        {200, :map},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
+        {404, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end
@@ -113,6 +117,7 @@ defmodule OpenApiTypesense.Documents do
       response: [
         {200, {OpenApiTypesense.Documents, :delete_documents_200_json_resp}},
         {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -175,6 +180,7 @@ defmodule OpenApiTypesense.Documents do
       method: :delete,
       response: [
         {200, {OpenApiTypesense.SearchOverrideDeleteResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -236,7 +242,11 @@ defmodule OpenApiTypesense.Documents do
       url: "/collections/#{collectionName}/documents/export",
       method: :get,
       query: query,
-      response: [{200, {:string, :generic}}, {404, {OpenApiTypesense.ApiResponse, :t}}],
+      response: [
+        {200, {:string, :generic}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
+        {404, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end
@@ -297,7 +307,11 @@ defmodule OpenApiTypesense.Documents do
       url: "/collections/#{collectionName}/documents/#{documentId}",
       method: :get,
       query: query,
-      response: [{200, :map}, {404, {OpenApiTypesense.ApiResponse, :t}}],
+      response: [
+        {200, :map},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
+        {404, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end
@@ -308,7 +322,8 @@ defmodule OpenApiTypesense.Documents do
   Retrieve the details of a search override, given its id.
   """
   @spec get_search_override(String.t(), String.t()) ::
-          {:ok, OpenApiTypesense.SearchOverride.t()} | :error
+          {:ok, OpenApiTypesense.SearchOverride.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_search_override(collectionName, overrideId) do
     get_search_override(Connection.new(), collectionName, overrideId)
   end
@@ -324,7 +339,8 @@ defmodule OpenApiTypesense.Documents do
           String.t(),
           String.t() | keyword()
         ) ::
-          {:ok, OpenApiTypesense.SearchOverride.t()} | :error
+          {:ok, OpenApiTypesense.SearchOverride.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_search_override(collectionName, overrideId, opts)
       when is_list(opts) and is_binary(collectionName) do
     get_search_override(Connection.new(), collectionName, overrideId, opts)
@@ -340,7 +356,8 @@ defmodule OpenApiTypesense.Documents do
   - `get_search_override(Connection.new(), collectionName, overrideId, opts)`
   """
   @spec get_search_override(map() | Connection.t(), String.t(), String.t(), keyword()) ::
-          {:ok, OpenApiTypesense.SearchOverride.t()} | :error
+          {:ok, OpenApiTypesense.SearchOverride.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_search_override(conn, collectionName, overrideId, opts)
       when not is_struct(conn) and is_map(conn) do
     get_search_override(Connection.new(conn), collectionName, overrideId, opts)
@@ -357,6 +374,7 @@ defmodule OpenApiTypesense.Documents do
       method: :get,
       response: [
         {200, {OpenApiTypesense.SearchOverride, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -367,7 +385,8 @@ defmodule OpenApiTypesense.Documents do
   List all collection overrides
   """
   @spec get_search_overrides(String.t()) ::
-          {:ok, OpenApiTypesense.SearchOverridesResponse.t()} | :error
+          {:ok, OpenApiTypesense.SearchOverridesResponse.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_search_overrides(collectionName) do
     get_search_overrides(Connection.new(), collectionName)
   end
@@ -379,7 +398,8 @@ defmodule OpenApiTypesense.Documents do
   - `get_search_overrides(Connection.new(), collectionName)`
   """
   @spec get_search_overrides(map() | Connection.t() | String.t(), String.t() | keyword()) ::
-          {:ok, OpenApiTypesense.SearchOverridesResponse.t()} | :error
+          {:ok, OpenApiTypesense.SearchOverridesResponse.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_search_overrides(collectionName, opts)
       when is_list(opts) and is_binary(collectionName) do
     get_search_overrides(Connection.new(), collectionName, opts)
@@ -395,7 +415,8 @@ defmodule OpenApiTypesense.Documents do
   - `get_search_overrides(Connection.new(), collectionName, opts)`
   """
   @spec get_search_overrides(map() | Connection.t(), String.t(), keyword()) ::
-          {:ok, OpenApiTypesense.SearchOverridesResponse.t()} | :error
+          {:ok, OpenApiTypesense.SearchOverridesResponse.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_search_overrides(conn, collectionName, opts)
       when not is_struct(conn) and is_map(conn) do
     get_search_overrides(Connection.new(conn), collectionName, opts)
@@ -411,6 +432,7 @@ defmodule OpenApiTypesense.Documents do
       method: :get,
       response: [
         {200, {OpenApiTypesense.SearchOverridesResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -495,6 +517,7 @@ defmodule OpenApiTypesense.Documents do
       response: [
         {200, {:string, :generic}},
         {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -561,6 +584,7 @@ defmodule OpenApiTypesense.Documents do
       request: [{"application/json", :map}],
       response: [
         {201, :map},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}},
         {409, {OpenApiTypesense.ApiResponse, :t}}
       ],
@@ -629,7 +653,8 @@ defmodule OpenApiTypesense.Documents do
       request: [{"application/json", {OpenApiTypesense.MultiSearchSearchesParameter, :t}}],
       response: [
         {200, {OpenApiTypesense.MultiSearchResult, :t}},
-        {400, {OpenApiTypesense.ApiResponse, :t}}
+        {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
     })
@@ -688,6 +713,7 @@ defmodule OpenApiTypesense.Documents do
       response: [
         {200, {OpenApiTypesense.SearchResult, :t}},
         {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: params
@@ -757,7 +783,11 @@ defmodule OpenApiTypesense.Documents do
       method: :patch,
       query: query,
       request: [{"application/json", :map}],
-      response: [{200, :map}, {404, {OpenApiTypesense.ApiResponse, :t}}],
+      response: [
+        {200, :map},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
+        {404, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end
@@ -808,6 +838,7 @@ defmodule OpenApiTypesense.Documents do
       response: [
         {200, {OpenApiTypesense.Documents, :update_documents_200_json_resp}},
         {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -872,6 +903,7 @@ defmodule OpenApiTypesense.Documents do
       request: [{"application/json", {OpenApiTypesense.SearchOverrideSchema, :t}}],
       response: [
         {200, {OpenApiTypesense.SearchOverride, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts

--- a/lib/open_api_typesense/operations/keys.ex
+++ b/lib/open_api_typesense/operations/keys.ex
@@ -58,6 +58,7 @@ defmodule OpenApiTypesense.Keys do
       response: [
         {201, {OpenApiTypesense.ApiKey, :t}},
         {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {409, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -117,6 +118,7 @@ defmodule OpenApiTypesense.Keys do
       response: [
         {200, {OpenApiTypesense.ApiKeyDeleteResponse, :t}},
         {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -169,7 +171,11 @@ defmodule OpenApiTypesense.Keys do
       call: {OpenApiTypesense.Keys, :get_key},
       url: "/keys/#{keyId}",
       method: :get,
-      response: [{200, {OpenApiTypesense.ApiKey, :t}}, {404, {OpenApiTypesense.ApiResponse, :t}}],
+      response: [
+        {200, {OpenApiTypesense.ApiKey, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
+        {404, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end

--- a/lib/open_api_typesense/operations/operations.ex
+++ b/lib/open_api_typesense/operations/operations.ex
@@ -13,7 +13,8 @@ defmodule OpenApiTypesense.Operations do
   Retrieve the stats about API endpoints.
   """
   @spec retrieve_api_stats ::
-          {:ok, OpenApiTypesense.APIStatsResponse.t()} | :error
+          {:ok, OpenApiTypesense.APIStatsResponse.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_api_stats do
     retrieve_api_stats(Connection.new())
   end
@@ -25,7 +26,8 @@ defmodule OpenApiTypesense.Operations do
   - `retrieve_api_stats(Connection.new())`
   """
   @spec retrieve_api_stats(map() | Connection.t() | keyword()) ::
-          {:ok, OpenApiTypesense.APIStatsResponse.t()} | :error
+          {:ok, OpenApiTypesense.APIStatsResponse.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_api_stats(opts) when is_list(opts) do
     retrieve_api_stats(Connection.new(), opts)
   end
@@ -40,7 +42,8 @@ defmodule OpenApiTypesense.Operations do
   - `retrieve_api_stats(Connection.new(), opts)`
   """
   @spec retrieve_api_stats(map() | Connection.t(), keyword()) ::
-          {:ok, OpenApiTypesense.APIStatsResponse.t()} | :error
+          {:ok, OpenApiTypesense.APIStatsResponse.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_api_stats(conn, opts) when not is_struct(conn) and is_map(conn) do
     retrieve_api_stats(Connection.new(conn), opts)
   end
@@ -53,7 +56,10 @@ defmodule OpenApiTypesense.Operations do
       call: {OpenApiTypesense.Operations, :retrieve_api_stats},
       url: "/stats.json",
       method: :get,
-      response: [{200, {OpenApiTypesense.APIStatsResponse, :t}}],
+      response: [
+        {200, {OpenApiTypesense.APIStatsResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end
@@ -63,7 +69,7 @@ defmodule OpenApiTypesense.Operations do
 
   Retrieve the metrics.
   """
-  @spec retrieve_metrics :: {:ok, map} | :error
+  @spec retrieve_metrics :: {:ok, map} | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_metrics do
     retrieve_metrics(Connection.new())
   end
@@ -74,7 +80,8 @@ defmodule OpenApiTypesense.Operations do
   - `retrieve_metrics(%{api_key: xyz, host: ...})`
   - `retrieve_metrics(Connection.new())`
   """
-  @spec retrieve_metrics(map() | Connection.t() | keyword()) :: {:ok, map()} | :error
+  @spec retrieve_metrics(map() | Connection.t() | keyword()) ::
+          {:ok, map()} | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_metrics(opts) when is_list(opts) do
     retrieve_metrics(Connection.new(), opts)
   end
@@ -88,7 +95,8 @@ defmodule OpenApiTypesense.Operations do
   - `retrieve_metrics(%{api_key: xyz, host: ...}, opts)`
   - `retrieve_metrics(Connection.new(), opts)`
   """
-  @spec retrieve_metrics(map() | Connection.t(), keyword()) :: {:ok, map()} | :error
+  @spec retrieve_metrics(map() | Connection.t(), keyword()) ::
+          {:ok, map()} | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_metrics(conn, opts) when not is_struct(conn) and is_map(conn) do
     retrieve_metrics(Connection.new(conn), opts)
   end
@@ -101,7 +109,10 @@ defmodule OpenApiTypesense.Operations do
       call: {OpenApiTypesense.Operations, :retrieve_metrics},
       url: "/metrics.json",
       method: :get,
-      response: [{200, :map}],
+      response: [
+        {200, :map},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end
@@ -116,7 +127,8 @@ defmodule OpenApiTypesense.Operations do
     * `snapshot_path`: The directory on the server where the snapshot should be saved.
 
   """
-  @spec take_snapshot(keyword()) :: {:ok, OpenApiTypesense.SuccessStatus.t()} | :error
+  @spec take_snapshot(keyword()) ::
+          {:ok, OpenApiTypesense.SuccessStatus.t()} | {:error, OpenApiTypesense.ApiResponse.t()}
   def take_snapshot(opts) do
     take_snapshot(Connection.new(), opts)
   end
@@ -127,7 +139,7 @@ defmodule OpenApiTypesense.Operations do
   - `take_snapshot(Connection.new(), opts)`
   """
   @spec take_snapshot(map() | Connection.t(), keyword()) ::
-          {:ok, OpenApiTypesense.SuccessStatus.t()} | :error
+          {:ok, OpenApiTypesense.SuccessStatus.t()} | {:error, OpenApiTypesense.ApiResponse.t()}
   def take_snapshot(conn, opts) when not is_struct(conn) and is_map(conn) do
     take_snapshot(Connection.new(conn), opts)
   end
@@ -144,6 +156,7 @@ defmodule OpenApiTypesense.Operations do
       query: query,
       response: [
         {201, {OpenApiTypesense.SuccessStatus, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {409, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -155,7 +168,9 @@ defmodule OpenApiTypesense.Operations do
 
   Typesense uses RocksDB to store your documents on the disk. If you do frequent writes or updates, you could benefit from running a compaction of the underlying RocksDB database. This could reduce the size of the database and decrease read latency. While the database will not block during this operation, we recommend running it during off-peak hours.
   """
-  @spec compact :: {:ok, OpenApiTypesense.SuccessStatus.t()} | :error
+  @spec compact ::
+          {:ok, OpenApiTypesense.SuccessStatus.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def compact do
     compact(Connection.new())
   end
@@ -167,7 +182,8 @@ defmodule OpenApiTypesense.Operations do
   - `compact(Connection.new())`
   """
   @spec compact(map() | Connection.t() | keyword()) ::
-          {:ok, OpenApiTypesense.SuccessStatus.t()} | :error
+          {:ok, OpenApiTypesense.SuccessStatus.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def compact(opts) when is_list(opts) do
     compact(Connection.new(), opts)
   end
@@ -182,7 +198,8 @@ defmodule OpenApiTypesense.Operations do
   - `compact(Connection.new(), opts)`
   """
   @spec compact(map() | Connection.t(), keyword()) ::
-          {:ok, OpenApiTypesense.SuccessStatus.t()} | :error
+          {:ok, OpenApiTypesense.SuccessStatus.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def compact(conn, opts) when not is_struct(conn) and is_map(conn) do
     compact(Connection.new(conn), opts)
   end
@@ -195,7 +212,10 @@ defmodule OpenApiTypesense.Operations do
       call: {OpenApiTypesense.Operations, :compact},
       url: "/operations/db/compact",
       method: :post,
-      response: [{200, {OpenApiTypesense.SuccessStatus, :t}}],
+      response: [
+        {200, {OpenApiTypesense.SuccessStatus, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end
@@ -205,7 +225,9 @@ defmodule OpenApiTypesense.Operations do
 
   Responses of search requests that are sent with use_cache parameter are cached in a LRU cache. Clears cache completely.
   """
-  @spec clear_cache :: {:ok, OpenApiTypesense.SuccessStatus.t()} | :error
+  @spec clear_cache ::
+          {:ok, OpenApiTypesense.SuccessStatus.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def clear_cache do
     clear_cache(Connection.new())
   end
@@ -217,7 +239,8 @@ defmodule OpenApiTypesense.Operations do
   - `clear_cache(Connection.new())`
   """
   @spec clear_cache(map() | Connection.t() | keyword()) ::
-          {:ok, OpenApiTypesense.SuccessStatus.t()} | :error
+          {:ok, OpenApiTypesense.SuccessStatus.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def clear_cache(opts) when is_list(opts) do
     clear_cache(Connection.new(), opts)
   end
@@ -232,7 +255,8 @@ defmodule OpenApiTypesense.Operations do
   - `clear_cache(Connection.new(), opts)`
   """
   @spec clear_cache(map() | Connection.t(), keyword()) ::
-          {:ok, OpenApiTypesense.SuccessStatus.t()} | :error
+          {:ok, OpenApiTypesense.SuccessStatus.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def clear_cache(conn, opts) when not is_struct(conn) and is_map(conn) do
     clear_cache(Connection.new(conn), opts)
   end
@@ -245,7 +269,10 @@ defmodule OpenApiTypesense.Operations do
       call: {OpenApiTypesense.Operations, :clear_cache},
       url: "/operations/cache/clear",
       method: :post,
-      response: [{200, {OpenApiTypesense.SuccessStatus, :t}}],
+      response: [
+        {200, {OpenApiTypesense.SuccessStatus, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end
@@ -261,7 +288,8 @@ defmodule OpenApiTypesense.Operations do
 
   """
   @spec config(map()) ::
-          {:ok, OpenApiTypesense.SuccessStatus.t()} | :error
+          {:ok, OpenApiTypesense.SuccessStatus.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def config(body) do
     config(Connection.new(), body)
   end
@@ -273,7 +301,8 @@ defmodule OpenApiTypesense.Operations do
   - `config(Connection.new(), payload)`
   """
   @spec config(map() | Connection.t(), map() | keyword()) ::
-          {:ok, OpenApiTypesense.SuccessStatus.t()} | :error
+          {:ok, OpenApiTypesense.SuccessStatus.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def config(body, opts) when is_list(opts) and is_map(body) do
     config(Connection.new(), body, opts)
   end
@@ -288,7 +317,8 @@ defmodule OpenApiTypesense.Operations do
   - `config(Connection.new(), payload, opts)`
   """
   @spec config(map() | Connection.t(), map(), keyword()) ::
-          {:ok, OpenApiTypesense.SuccessStatus.t()} | :error
+          {:ok, OpenApiTypesense.SuccessStatus.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def config(conn, body, opts) when not is_struct(conn) and is_map(conn) do
     config(Connection.new(conn), body, opts)
   end
@@ -303,7 +333,10 @@ defmodule OpenApiTypesense.Operations do
       body: body,
       method: :post,
       request: [{"application/json", {OpenApiTypesense.ConfigSchema, :t}}],
-      response: [{201, {OpenApiTypesense.SuccessStatus, :t}}],
+      response: [
+        {201, {OpenApiTypesense.SuccessStatus, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end
@@ -313,7 +346,8 @@ defmodule OpenApiTypesense.Operations do
 
   Triggers a follower node to initiate the raft voting process, which triggers leader re-election. The follower node that you run this operation against will become the new leader, once this command succeeds.
   """
-  @spec vote :: {:ok, OpenApiTypesense.SuccessStatus.t()} | :error
+  @spec vote ::
+          {:ok, OpenApiTypesense.SuccessStatus.t()} | {:error, OpenApiTypesense.ApiResponse.t()}
   def vote do
     vote(Connection.new())
   end
@@ -325,7 +359,7 @@ defmodule OpenApiTypesense.Operations do
   - `vote(Connection.new())`
   """
   @spec vote(map() | Connection.t() | keyword()) ::
-          {:ok, OpenApiTypesense.SuccessStatus.t()} | :error
+          {:ok, OpenApiTypesense.SuccessStatus.t()} | {:error, OpenApiTypesense.ApiResponse.t()}
   def vote(opts) when is_list(opts) do
     vote(Connection.new(), opts)
   end
@@ -340,7 +374,7 @@ defmodule OpenApiTypesense.Operations do
   - `vote(Connection.new(), opts)`
   """
   @spec vote(map() | Connection.t(), keyword()) ::
-          {:ok, OpenApiTypesense.SuccessStatus.t()} | :error
+          {:ok, OpenApiTypesense.SuccessStatus.t()} | {:error, OpenApiTypesense.ApiResponse.t()}
   def vote(conn, opts) when not is_struct(conn) and is_map(conn) do
     vote(Connection.new(conn), opts)
   end
@@ -353,7 +387,10 @@ defmodule OpenApiTypesense.Operations do
       call: {OpenApiTypesense.Operations, :vote},
       url: "/operations/vote",
       method: :post,
-      response: [{200, {OpenApiTypesense.SuccessStatus, :t}}],
+      response: [
+        {200, {OpenApiTypesense.SuccessStatus, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end

--- a/lib/open_api_typesense/operations/override.ex
+++ b/lib/open_api_typesense/operations/override.ex
@@ -13,7 +13,7 @@ defmodule OpenApiTypesense.Override do
   Retrieve the details of a search override, given its id.
   """
   @spec get_search_override(String.t(), String.t()) ::
-          {:ok, OpenApiTypesense.SearchOverride.t()} | :error
+          {:ok, OpenApiTypesense.SearchOverride.t()} | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_search_override(collectionName, overrideId) do
     get_search_override(Connection.new(), collectionName, overrideId)
   end
@@ -29,7 +29,7 @@ defmodule OpenApiTypesense.Override do
           String.t(),
           String.t() | keyword()
         ) ::
-          {:ok, OpenApiTypesense.SearchOverride.t()} | :error
+          {:ok, OpenApiTypesense.SearchOverride.t()} | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_search_override(collectionName, overrideId, opts)
       when is_list(opts) and is_binary(collectionName) do
     get_search_override(Connection.new(), collectionName, overrideId, opts)
@@ -45,7 +45,7 @@ defmodule OpenApiTypesense.Override do
   - `get_search_override(Connection.new(), collectionName, overrideId, opts)`
   """
   @spec get_search_override(map() | Connection.t(), String.t(), String.t(), keyword()) ::
-          {:ok, OpenApiTypesense.SearchOverride.t()} | :error
+          {:ok, OpenApiTypesense.SearchOverride.t()} | {:error, OpenApiTypesense.ApiResponse.t()}
   def get_search_override(conn, collectionName, overrideId, opts)
       when not is_struct(conn) and is_map(conn) do
     get_search_override(Connection.new(conn), collectionName, overrideId, opts)
@@ -62,6 +62,7 @@ defmodule OpenApiTypesense.Override do
       method: :get,
       response: [
         {200, {OpenApiTypesense.SearchOverride, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts

--- a/lib/open_api_typesense/operations/presets.ex
+++ b/lib/open_api_typesense/operations/presets.ex
@@ -61,6 +61,7 @@ defmodule OpenApiTypesense.Presets do
       method: :delete,
       response: [
         {200, {OpenApiTypesense.PresetDeleteSchema, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -73,7 +74,8 @@ defmodule OpenApiTypesense.Presets do
   Retrieve the details of all presets
   """
   @spec retrieve_all_presets ::
-          {:ok, OpenApiTypesense.PresetsRetrieveSchema.t()} | :error
+          {:ok, OpenApiTypesense.PresetsRetrieveSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_all_presets do
     retrieve_all_presets(Connection.new())
   end
@@ -85,7 +87,8 @@ defmodule OpenApiTypesense.Presets do
   - `retrieve_all_presets(Connection.new())`
   """
   @spec retrieve_all_presets(map() | Connection.t() | keyword()) ::
-          {:ok, OpenApiTypesense.PresetsRetrieveSchema.t()} | :error
+          {:ok, OpenApiTypesense.PresetsRetrieveSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_all_presets(opts) when is_list(opts) do
     retrieve_all_presets(Connection.new(), opts)
   end
@@ -100,7 +103,8 @@ defmodule OpenApiTypesense.Presets do
   - `retrieve_all_presets(Connection.new(), opts)`
   """
   @spec retrieve_all_presets(map() | Connection.t(), keyword()) ::
-          {:ok, OpenApiTypesense.PresetsRetrieveSchema.t()} | :error
+          {:ok, OpenApiTypesense.PresetsRetrieveSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_all_presets(conn, opts) when not is_struct(conn) and is_map(conn) do
     retrieve_all_presets(Connection.new(conn), opts)
   end
@@ -113,7 +117,10 @@ defmodule OpenApiTypesense.Presets do
       call: {OpenApiTypesense.Presets, :retrieve_all_presets},
       url: "/presets",
       method: :get,
-      response: [{200, {OpenApiTypesense.PresetsRetrieveSchema, :t}}],
+      response: [
+        {200, {OpenApiTypesense.PresetsRetrieveSchema, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end
@@ -166,6 +173,7 @@ defmodule OpenApiTypesense.Presets do
       method: :get,
       response: [
         {200, {OpenApiTypesense.PresetSchema, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -222,7 +230,8 @@ defmodule OpenApiTypesense.Presets do
       request: [{"application/json", {OpenApiTypesense.PresetUpsertSchema, :t}}],
       response: [
         {200, {OpenApiTypesense.PresetSchema, :t}},
-        {400, {OpenApiTypesense.ApiResponse, :t}}
+        {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
     })

--- a/lib/open_api_typesense/operations/stopwords.ex
+++ b/lib/open_api_typesense/operations/stopwords.ex
@@ -59,6 +59,7 @@ defmodule OpenApiTypesense.Stopwords do
       method: :delete,
       response: [
         {200, {OpenApiTypesense.Stopwords, :delete_stopwords_set_200_json_resp}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -116,6 +117,7 @@ defmodule OpenApiTypesense.Stopwords do
       method: :get,
       response: [
         {200, {OpenApiTypesense.StopwordsSetRetrieveSchema, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -128,7 +130,8 @@ defmodule OpenApiTypesense.Stopwords do
   Retrieve the details of all stopwords sets
   """
   @spec retrieve_stopwords_sets ::
-          {:ok, OpenApiTypesense.StopwordsSetsRetrieveAllSchema.t()} | :error
+          {:ok, OpenApiTypesense.StopwordsSetsRetrieveAllSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_stopwords_sets do
     retrieve_stopwords_sets(Connection.new())
   end
@@ -140,7 +143,8 @@ defmodule OpenApiTypesense.Stopwords do
   - `retrieve_stopwords_sets(Connection.new())`
   """
   @spec retrieve_stopwords_sets(map() | Connection.t() | keyword()) ::
-          {:ok, OpenApiTypesense.StopwordsSetsRetrieveAllSchema.t()} | :error
+          {:ok, OpenApiTypesense.StopwordsSetsRetrieveAllSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_stopwords_sets(opts) when is_list(opts) do
     retrieve_stopwords_sets(Connection.new(), opts)
   end
@@ -155,7 +159,8 @@ defmodule OpenApiTypesense.Stopwords do
   - `retrieve_stopwords_sets(Connection.new(), opts)`
   """
   @spec retrieve_stopwords_sets(map() | Connection.t(), keyword()) ::
-          {:ok, OpenApiTypesense.StopwordsSetsRetrieveAllSchema.t()} | :error
+          {:ok, OpenApiTypesense.StopwordsSetsRetrieveAllSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def retrieve_stopwords_sets(conn, opts) when not is_struct(conn) and is_map(conn) do
     retrieve_stopwords_sets(Connection.new(conn), opts)
   end
@@ -168,7 +173,10 @@ defmodule OpenApiTypesense.Stopwords do
       call: {OpenApiTypesense.Stopwords, :retrieve_stopwords_sets},
       url: "/stopwords",
       method: :get,
-      response: [{200, {OpenApiTypesense.StopwordsSetsRetrieveAllSchema, :t}}],
+      response: [
+        {200, {OpenApiTypesense.StopwordsSetsRetrieveAllSchema, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
+      ],
       opts: opts
     })
   end
@@ -230,7 +238,8 @@ defmodule OpenApiTypesense.Stopwords do
       request: [{"application/json", {OpenApiTypesense.StopwordsSetUpsertSchema, :t}}],
       response: [
         {200, {OpenApiTypesense.StopwordsSetSchema, :t}},
-        {400, {OpenApiTypesense.ApiResponse, :t}}
+        {400, {OpenApiTypesense.ApiResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
     })

--- a/lib/open_api_typesense/operations/synonyms.ex
+++ b/lib/open_api_typesense/operations/synonyms.ex
@@ -68,6 +68,7 @@ defmodule OpenApiTypesense.Synonyms do
       method: :delete,
       response: [
         {200, {OpenApiTypesense.SearchSynonymDeleteResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -129,6 +130,7 @@ defmodule OpenApiTypesense.Synonyms do
       method: :get,
       response: [
         {200, {OpenApiTypesense.SearchSynonym, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -193,6 +195,7 @@ defmodule OpenApiTypesense.Synonyms do
       query: query,
       response: [
         {200, {OpenApiTypesense.SearchSynonymsResponse, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
@@ -257,6 +260,7 @@ defmodule OpenApiTypesense.Synonyms do
       request: [{"application/json", {OpenApiTypesense.SearchSynonymSchema, :t}}],
       response: [
         {200, {OpenApiTypesense.SearchSynonym, :t}},
+        {401, {OpenApiTypesense.ApiResponse, :t}},
         {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule OpenApiTypesense.MixProject do
 
   @source_url "https://github.com/jaeyson/open_api_typesense"
   @hex_url "https://hexdocs.pm/open_api_typesense"
-  @version "0.6.0"
+  @version "0.6.1"
 
   def project do
     [

--- a/priv/open_api.yml
+++ b/priv/open_api.yml
@@ -86,6 +86,12 @@ paths:
                 x-go-type: '[]*CollectionResponse'
                 items:
                   $ref: '#/components/schemas/CollectionResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
       parameters:
         - name: limit
           in: query
@@ -126,6 +132,12 @@ paths:
                 $ref: '#/components/schemas/CollectionResponse'
         '400':
           description: 'Bad request, see error message for details'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          description: 'Missing API key'
           content:
             application/json:
               schema:
@@ -206,6 +218,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: The collection was not found
           content:
@@ -234,6 +252,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CollectionResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Collection not found
           content:
@@ -285,6 +309,12 @@ paths:
               schema:
                 type: object
                 description: Can be any key-value pair
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Collection not found
           content:
@@ -349,6 +379,12 @@ paths:
                     example: 1
         '400':
           description: 'Bad request, see error message for details'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          description: 'Missing API key'
           content:
             application/json:
               schema:
@@ -419,6 +455,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Collection not found
           content:
@@ -453,6 +495,12 @@ paths:
                 $ref: '#/components/schemas/SearchResult'
         '400':
           description: 'Bad request, see error message for details'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          description: 'Missing API key'
           content:
             application/json:
               schema:
@@ -494,6 +542,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SearchOverridesResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: List of search overrides not found
           content:
@@ -528,6 +582,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SearchOverride'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Search override not found
           content:
@@ -571,6 +631,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SearchOverride'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Search override not found
           content:
@@ -603,6 +669,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SearchOverrideDeleteResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Search override not found
           content:
@@ -639,6 +711,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SearchSynonymsResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Search synonyms was not found
           content:
@@ -672,6 +750,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SearchSynonym'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Search synonym was not found
           content:
@@ -713,6 +797,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SearchSynonym'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Search synonym was not found
           content:
@@ -744,6 +834,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SearchSynonymDeleteResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Search synonym not found
           content:
@@ -797,6 +893,12 @@ paths:
 
                   {"id": "126", "company_name": "Random Corp.", "num_employees":
                   531,"country": "AU"}
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: The collection was not found
           content:
@@ -907,6 +1009,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: The collection was not found
           content:
@@ -953,6 +1061,12 @@ paths:
               schema:
                 type: object
                 description: Can be any key-value pair
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: The document or collection was not found
           content:
@@ -1002,6 +1116,12 @@ paths:
               schema:
                 type: object
                 description: Can be any key-value pair
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: The document or collection was not found
           content:
@@ -1040,6 +1160,12 @@ paths:
               schema:
                 type: object
                 description: Can be any key-value pair
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: The document or collection was not found
           content:
@@ -1060,6 +1186,12 @@ paths:
                 type: array
                 x-go-type: '[]*ConversationModelSchema'
           description: List of all conversation models
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
       summary: List all conversation models
       tags:
         - conversations
@@ -1079,6 +1211,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ConversationModelSchema'
           description: Created Conversation Model
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '400':
           content:
             application/json:
@@ -1105,6 +1243,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ConversationModelSchema'
           description: A conversation model
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Model not found
           content:
@@ -1137,6 +1281,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ConversationModelSchema'
           description: The conversation model was successfully updated
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Model not found
           content:
@@ -1163,6 +1313,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ConversationModelSchema'
           description: The conversation model was successfully deleted
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Model not found
           content:
@@ -1214,6 +1370,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '409':
           description: API key generation conflict
           content:
@@ -1245,6 +1407,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiKey'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: The key was not found
           content:
@@ -1277,6 +1445,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Key not found
           content:
@@ -1297,6 +1471,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CollectionAliasesResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
   '/aliases/{aliasName}':
     put:
       tags:
@@ -1335,6 +1515,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Alias not found
           content:
@@ -1361,6 +1547,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CollectionAlias'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: The alias was not found
           content:
@@ -1386,6 +1578,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CollectionAlias'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Alias not found
           content:
@@ -1409,6 +1607,12 @@ paths:
                 properties:
                   version:
                     type: string
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
   /health:
     get:
       tags:
@@ -1449,6 +1653,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessStatus'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '409':
           description: Another snapshot is in progress.
           content:
@@ -1475,6 +1685,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessStatus'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
   /operations/db/compact:
     post:
       tags:
@@ -1494,6 +1710,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessStatus'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
   /operations/cache/clear:
     post:
       tags:
@@ -1510,6 +1732,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessStatus'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
   /config:
     post:
       tags:
@@ -1532,6 +1760,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessStatus'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
   /multi_search:
     post:
       operationId: multiSearch
@@ -1579,6 +1813,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
   /analytics/events:
     post:
       tags:
@@ -1604,6 +1844,12 @@ paths:
                 $ref: '#/components/schemas/AnalyticsEventCreateResponse'
         '400':
           description: 'Bad request, see error message for details'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '401':
+          description: 'Missing API key'
           content:
             application/json:
               schema:
@@ -1637,6 +1883,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Collection or field missing
           content:
@@ -1656,6 +1908,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AnalyticsRulesRetrieveSchema'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
   '/analytics/rules/{ruleName}':
     put:
       tags:
@@ -1690,6 +1948,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
     get:
       tags:
         - analytics
@@ -1710,6 +1974,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AnalyticsRuleSchema'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Analytics rule not found
           content:
@@ -1756,6 +2026,12 @@ paths:
             application/json:
               schema:
                 type: object
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
   /stats.json:
     get:
       tags:
@@ -1770,6 +2046,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIStatsResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
   /stopwords:
     get:
       tags:
@@ -1784,6 +2066,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StopwordsSetsRetrieveAllSchema'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
   '/stopwords/{setId}':
     put:
       tags:
@@ -1821,6 +2109,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
     get:
       tags:
         - stopwords
@@ -1842,6 +2136,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StopwordsSetRetrieveSchema'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Stopwords set not found.
           content:
@@ -1876,6 +2176,12 @@ paths:
                   - id
                 example: |
                   {"id": "countries"}
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Stopwords set not found.
           content:
@@ -1896,6 +2202,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PresetsRetrieveSchema'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
   '/presets/{presetId}':
     get:
       tags:
@@ -1918,6 +2230,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PresetSchema'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Preset not found.
           content:
@@ -1958,6 +2276,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
     delete:
       tags:
         - presets
@@ -1979,6 +2303,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PresetDeleteSchema'
+        '401':
+          description: 'Missing API key'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '404':
           description: Preset not found.
           content:


### PR DESCRIPTION
Fixes #15

## Summary by Sourcery

Bug Fixes:
- Return a 401 error code when the API key is missing.