### PR TITLE
Use config_env/0 instead of Mix.env/0

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 import Config
 
-if Mix.env() in [:dev, :test] do
+if config_env() in [:dev, :test] do
   config :open_api_typesense,
     api_key: "xyz",
     host: "localhost",


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Replace Mix.env/0 with config_env/0 for environment configuration.