### PR TITLE
Update duplicate collection name in join_test

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,21 +1,5 @@
 import Config
 
-if config_env() in [:dev, :test] do
-  config :open_api_typesense,
-    api_key: "xyz",
-    host: "localhost",
-    port: 8108,
-    scheme: "http"
-end
-
-if config_env() in [:dev] do
-  config :oapi_generator,
-    default: [
-      output: [
-        base_module: OpenApiTypesense,
-        location: "lib/open_api_typesense",
-        operation_subdirectory: "operations/",
-        schema_subdirectory: "schemas/"
-      ]
-    ]
-end
+# Import environment specific config. This must remain at the bottom
+# of this file so it overrides the configuration defined above.
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,17 @@
+import Config
+
+config :open_api_typesense,
+  api_key: "xyz",
+  host: "localhost",
+  port: 8108,
+  scheme: "http"
+
+config :oapi_generator,
+  default: [
+    output: [
+      base_module: OpenApiTypesense,
+      location: "lib/open_api_typesense",
+      operation_subdirectory: "operations/",
+      schema_subdirectory: "schemas/"
+    ]
+  ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,9 @@
+import Config
+
+config :open_api_typesense,
+  api_key: "xyz",
+  host: "localhost",
+  port: 8108,
+  scheme: "http",
+  max_retries: 0,
+  retry: false

--- a/lib/open_api_typesense/client.ex
+++ b/lib/open_api_typesense/client.ex
@@ -37,6 +37,9 @@ defmodule OpenApiTypesense.Client do
   @spec get_client :: keyword() | nil
   def get_client, do: Application.get_env(:open_api_typesense, :client)
 
+  defp test_max_retries, do: Application.get_env(:open_api_typesense, :max_retries)
+  defp test_retry, do: Application.get_env(:open_api_typesense, :retry)
+
   @doc """
   Returns the Typesense's API key
 
@@ -110,8 +113,8 @@ defmodule OpenApiTypesense.Client do
         method: opts[:method] || :get,
         body: encode_body(opts),
         url: url,
-        max_retries: opts[:req][:max_retries] || 3,
-        retry: opts[:req][:retry] || :safe_transient,
+        max_retries: test_max_retries() || opts[:req][:max_retries] || 3,
+        retry: test_retry() || opts[:req][:retry] || :safe_transient,
         compress_body: opts[:req][:compress] || false,
         cache: opts[:req][:cache] || false,
         decode_json: [keys: :atoms]

--- a/test/operations/collections_test.exs
+++ b/test/operations/collections_test.exs
@@ -104,7 +104,7 @@ defmodule CollectionsTest do
 
     body = %{fields: [%{name: "price", drop: true}]}
 
-    assert {:ok, %CollectionUpdateSchema{}} =
+    assert {:ok, %CollectionUpdateSchema{fields: [%{name: "price", drop: true}]}} =
              Collections.update_collection(name, body)
 
     assert {:error, %ApiResponse{message: _}} = Collections.update_collection(name, body, [])

--- a/test/operations/join_test.exs
+++ b/test/operations/join_test.exs
@@ -45,7 +45,7 @@ defmodule JoinTest do
     }
 
     product_schema = %{
-      name: "products",
+      name: "join_products",
       fields: [
         %{name: "product_id", type: "string"},
         %{name: "product_name", type: "string"},
@@ -58,7 +58,7 @@ defmodule JoinTest do
       fields: [
         %{name: "title", type: "string"},
         %{name: "price", type: "float"},
-        %{name: "product_id", type: "string", reference: "products.product_id"}
+        %{name: "product_id", type: "string", reference: "join_products.product_id"}
       ]
     }
 
@@ -84,7 +84,7 @@ defmodule JoinTest do
       fields: [
         %{name: "customer_id", type: "string"},
         %{name: "custom_price", type: "float"},
-        %{name: "product_id", type: "string", reference: "products.product_id"}
+        %{name: "product_id", type: "string", reference: "join_products.product_id"}
       ]
     }
 
@@ -437,12 +437,12 @@ defmodule JoinTest do
       searches: [
         %{
           q: "*",
-          collection: "products",
+          collection: "join_products",
           filter_by: "$customer_product_prices(customer_id:=1)"
         },
         %{
           q: "*",
-          collection: "products",
+          collection: "join_products",
           filter_by: "$customer_product_prices(customer_id:=1 && custom_price:<=100)"
         }
       ]
@@ -626,7 +626,7 @@ defmodule JoinTest do
                   ]
                 }
               ]
-            }} = Documents.search("products", opts)
+            }} = Documents.search("join_products", opts)
   end
 
   @tag ["27.1": true, "27.0": true, "26.0": true]
@@ -660,6 +660,6 @@ defmodule JoinTest do
                   }
                 }
               ]
-            }} = Documents.search("products", opts)
+            }} = Documents.search("join_products", opts)
   end
 end

--- a/test/operations/join_test.exs
+++ b/test/operations/join_test.exs
@@ -325,8 +325,21 @@ defmodule JoinTest do
     end)
 
     on_exit(fn ->
-      {:ok, colls} = Collections.get_collections()
-      Enum.each(colls, &Collections.delete_collection(&1.name))
+      [
+        author_schema.name,
+        book_schema.name,
+        customer_schema.name,
+        order_schema.name,
+        product_schema.name,
+        product_variant_schema.name,
+        retailer_schema.name,
+        inventory_schema.name,
+        customer_product_prices_schema.name,
+        document_schema.name,
+        user_schema.name,
+        user_doc_access_schema.name
+      ]
+      |> Enum.each(&Collections.delete_collection/1)
     end)
 
     :ok

--- a/test/operations/join_test.exs
+++ b/test/operations/join_test.exs
@@ -1,7 +1,6 @@
 defmodule JoinTest do
   use ExUnit.Case, async: true
 
-  alias OpenApiTypesense.ApiResponse
   alias OpenApiTypesense.Collections
   alias OpenApiTypesense.Documents
   alias OpenApiTypesense.MultiSearchResult
@@ -113,18 +112,21 @@ defmodule JoinTest do
       ]
     }
 
-    {:ok, _} = Collections.create_collection(author_schema)
-    {:ok, _} = Collections.create_collection(book_schema)
-    {:ok, _} = Collections.create_collection(customer_schema)
-    {:ok, _} = Collections.create_collection(order_schema)
-    {:ok, _} = Collections.create_collection(product_schema)
-    {:ok, _} = Collections.create_collection(product_variant_schema)
-    {:ok, _} = Collections.create_collection(retailer_schema)
-    {:ok, _} = Collections.create_collection(inventory_schema)
-    {:ok, _} = Collections.create_collection(customer_product_prices_schema)
-    {:ok, _} = Collections.create_collection(document_schema)
-    {:ok, _} = Collections.create_collection(user_schema)
-    {:ok, _} = Collections.create_collection(user_doc_access_schema)
+    [
+      author_schema,
+      book_schema,
+      customer_schema,
+      order_schema,
+      product_schema,
+      product_variant_schema,
+      retailer_schema,
+      inventory_schema,
+      customer_product_prices_schema,
+      document_schema,
+      user_schema,
+      user_doc_access_schema
+    ]
+    |> Enum.each(&Collections.create_collection/1)
 
     [
       %{
@@ -323,18 +325,8 @@ defmodule JoinTest do
     end)
 
     on_exit(fn ->
-      {:ok, _} = Collections.delete_collection(author_schema.name)
-      {:ok, _} = Collections.delete_collection(book_schema.name)
-      {:ok, _} = Collections.delete_collection(customer_schema.name)
-      {:ok, _} = Collections.delete_collection(order_schema.name)
-      {:ok, _} = Collections.delete_collection(product_schema.name)
-      {:ok, _} = Collections.delete_collection(product_variant_schema.name)
-      {:ok, _} = Collections.delete_collection(retailer_schema.name)
-      {:ok, _} = Collections.delete_collection(inventory_schema.name)
-      {:ok, _} = Collections.delete_collection(customer_product_prices_schema.name)
-      {:ok, _} = Collections.delete_collection(document_schema.name)
-      {:ok, _} = Collections.delete_collection(user_schema.name)
-      {:ok, _} = Collections.delete_collection(user_doc_access_schema.name)
+      {:ok, colls} = Collections.get_collections()
+      Enum.each(colls, &Collections.delete_collection(&1.name))
     end)
 
     :ok


### PR DESCRIPTION
Fixes #23

## Summary by Sourcery

Bug Fixes:
- Fix an issue where the join tests were using the same collection name as other tests, potentially causing conflicts and unexpected results.