### PR TITLE
Refactor default Req client

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -4,7 +4,11 @@ config :open_api_typesense,
   api_key: "xyz",
   host: "localhost",
   port: 8108,
-  scheme: "http"
+  scheme: "http",
+  # see https://hexdocs.pm/req/Req.html#new/1
+  options: [
+    retry: false
+  ]
 
 config :oapi_generator,
   default: [

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,5 +5,7 @@ config :open_api_typesense,
   host: "localhost",
   port: 8108,
   scheme: "http",
-  max_retries: 0,
-  retry: false
+  # see https://hexdocs.pm/req/Req.html#new/1
+  options: [
+    retry: false
+  ]

--- a/lib/open_api_typesense/operations/health.ex
+++ b/lib/open_api_typesense/operations/health.ex
@@ -14,7 +14,9 @@ defmodule OpenApiTypesense.Health do
   """
 
   @spec health :: {:ok, OpenApiTypesense.HealthStatus.t()} | :error
-  def health, do: health(Connection.new())
+  def health do
+    health(Connection.new(), [])
+  end
 
   @doc """
   Either one of:
@@ -24,12 +26,12 @@ defmodule OpenApiTypesense.Health do
   """
   @spec health(Connection.t() | map() | keyword()) ::
           {:ok, OpenApiTypesense.HealthStatus.t()} | :error
-  def health(opts) when is_list(opts) do
-    health(Connection.new(), opts)
+  def health(conn) when is_struct(conn, Connection) do
+    health(conn, [])
   end
 
-  def health(conn) do
-    health(conn, [])
+  def health(conn) when is_map(conn) do
+    health(Connection.new(conn), [])
   end
 
   @doc """

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -17,7 +17,8 @@ defmodule ConnectionTest do
              api_key: "xyz",
              host: "localhost",
              port: 8108,
-             scheme: "http"
+             scheme: "http",
+             options: [retry: false]
            }
   end
 
@@ -35,7 +36,8 @@ defmodule ConnectionTest do
              api_key: "myapikey",
              host: "otherhost",
              port: 9200,
-             scheme: "https"
+             scheme: "https",
+             options: [retry: false]
            }
   end
 

--- a/test/custom_client_test.exs
+++ b/test/custom_client_test.exs
@@ -1,4 +1,4 @@
-defmodule ClientTest do
+defmodule CustomClientTest do
   use ExUnit.Case, async: false
   require Logger
 
@@ -110,7 +110,6 @@ defmodule ClientTest do
     assert CustomClient === Application.get_env(:open_api_typesense, :client)
 
     assert {:ok, %{"ok" => true}} = OpenApiTypesense.Health.health()
-    assert {:ok, %{"ok" => true}} = OpenApiTypesense.Health.health([])
     assert {:ok, %{"ok" => true}} = OpenApiTypesense.Health.health(conn)
     assert {:ok, %{"ok" => true}} = OpenApiTypesense.Health.health(map_conn)
     assert {:ok, %{"ok" => true}} = OpenApiTypesense.Health.health(conn, [])

--- a/test/default_client_test.exs
+++ b/test/default_client_test.exs
@@ -1,0 +1,39 @@
+defmodule DefaultClientTest do
+  use ExUnit.Case, async: false
+
+  alias OpenApiTypesense.Client
+  alias OpenApiTypesense.Connection
+
+  require Logger
+
+  describe "request/2" do
+    @tag ["27.1": true, "27.0": true, "26.0": true]
+    test "default to req http client if no custom client set" do
+      conn = Connection.new()
+
+      opts = %{
+        args: [],
+        call: {OpenApiTypesense.Health, :health},
+        url: "/health",
+        method: :get,
+        response: [{200, {OpenApiTypesense.HealthStatus, :t}}],
+        opts: []
+      }
+
+      assert {:ok, %OpenApiTypesense.HealthStatus{ok: true}} = Client.request(conn, opts)
+    end
+  end
+
+  describe "build_req_client/2" do
+    test "default req options" do
+      req = Client.build_req_client(Connection.new(), [])
+      assert req.headers == %{"x-typesense-api-key" => ["xyz"]}
+      assert req.options == %{decode_json: [keys: :atoms], retry: false}
+    end
+
+    test "override req options through req field" do
+      req = Client.build_req_client(Connection.new(), req: [retry: true, cache: false])
+      assert req.options == %{decode_json: [keys: :atoms], cache: false, retry: true}
+    end
+  end
+end

--- a/test/operations/health_test.exs
+++ b/test/operations/health_test.exs
@@ -15,7 +15,6 @@ defmodule HealthTest do
   @tag ["27.1": true, "27.0": true, "26.0": true]
   test "success: health check", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %HealthStatus{ok: true}} = Health.health()
-    assert {:ok, %HealthStatus{ok: true}} = Health.health([])
     assert {:ok, %HealthStatus{ok: true}} = Health.health(conn)
     assert {:ok, %HealthStatus{ok: true}} = Health.health(map_conn)
     assert {:ok, %HealthStatus{ok: true}} = Health.health(conn, [])


### PR DESCRIPTION
This commit refactors the existing default Req HTTP client to provide full support for all options documented in https://hexdocs.pm/req/Req.html#new/1.

Key changes:
- the client now accepts all options defined in Req.new/1
- global configuration can be set in `config.exs`
- per-function call overrides are possible using the `req` argument
- the Req client configuration has been deprecated and moved from the Client module to the Connection module

## Summary by Sourcery

Refactors the default Req HTTP client to provide full support for all options documented in Req.new/1. This includes the ability to set global configuration in `config.exs` and per-function call overrides using the `req` argument. The Req client configuration has been deprecated and moved from the Client module to the Connection module.

Enhancements:
- The default Req HTTP client is refactored to support all options documented in Req.new/1, allowing for more flexible configuration.
- Global Req client configuration can now be set in `config.exs`.
- Per-function call overrides are now possible using the `req` argument.

Chores:
- The Req client configuration has been deprecated and moved from the Client module to the Connection module.