### PR TITLE
Reduce unsafe atom keys conversion

### DIFF
--- a/lib/open_api_typesense/client.ex
+++ b/lib/open_api_typesense/client.ex
@@ -130,18 +130,20 @@ defmodule OpenApiTypesense.Client do
     Enum.map_join(body, "\n", &Jason.encode_to_iodata!/1)
   end
 
+  defp parse_content_type({"application/json", {mod, :t}}, body) when is_atom(mod) do
+    atom_keys = Map.keys(mod.__struct__()) |> Enum.reject(&(&1 == :__struct__))
+    string_keys = Enum.map(atom_keys, &to_string/1)
+    keys = atom_keys ++ string_keys
+
+    body
+    |> Map.take(keys)
+    |> OpenApiTypesense.Converter.to_atom_keys(safe: false)
+    |> Jason.encode_to_iodata!()
+  end
+
   defp parse_content_type({"application/json", _}, body) do
     Jason.encode_to_iodata!(body)
   end
-
-  # defp parse_content_type({"application/json", {mod, :t}}, body) do
-  #   # Checks if map keys are atom or string
-  #   if Enum.all?(Map.keys(body), &is_atom/1) do
-  #       Jason.encode_to_iodata!(struct(mod, body))
-  #   else
-  #     Jason.encode_to_iodata!(body)
-  #   end
-  # end
 
   # Some resources are missing 4xx descriptions, hence we will set a default
   # instead so we can see the actual error message instead of stacktrace.

--- a/lib/open_api_typesense/converter.ex
+++ b/lib/open_api_typesense/converter.ex
@@ -1,0 +1,155 @@
+defmodule OpenApiTypesense.Converter do
+  defstruct safe: true,
+            underscore: true,
+            high_perf: false,
+            ignore: false
+
+  @spec to_atom_keys(
+          map() | list() | tuple() | struct(),
+          map() | list() | %__MODULE__{}
+        ) :: map() | list() | tuple()
+  def to_atom_keys(value, opts \\ %{})
+
+  def to_atom_keys(%{__struct__: _type} = struct, %__MODULE__{} = opts) when is_struct(struct) do
+    struct
+    |> Map.from_struct()
+    |> to_atom_keys(opts)
+  end
+
+  def to_atom_keys(map, %__MODULE__{} = opts) when is_map(map) do
+    Map.new(map, fn {k, v} -> {convert_key(k, opts), to_atom_keys(v, opts)} end)
+  end
+
+  def to_atom_keys(list, %__MODULE__{} = opts) when is_list(list) do
+    Enum.map(list, &to_atom_keys(&1, opts))
+  end
+
+  def to_atom_keys(tuple, %__MODULE__{} = opts) when is_tuple(tuple) do
+    tuple
+    |> Tuple.to_list()
+    |> to_atom_keys(opts)
+    |> List.to_tuple()
+  end
+
+  def to_atom_keys(val, _opts = %__MODULE__{}) do
+    val
+  end
+
+  def to_atom_keys(val, opts = %{}) do
+    to_atom_keys(val, struct(__MODULE__, opts))
+  end
+
+  def to_atom_keys(val, opts) when is_list(opts) do
+    to_atom_keys(val, Enum.into(opts, %{}))
+  end
+
+  defp convert_key(key, opts) do
+    key
+    |> as_underscore(opts.underscore, opts.high_perf)
+    |> as_atom(opts.safe, opts.ignore)
+  end
+
+  @spec as_atom(String.t() | atom(), safe? :: boolean(), ignore? :: boolean()) ::
+          atom() | String.t()
+  defp as_atom(key, true, true) when is_binary(key) do
+    try do
+      as_atom(key, true, false)
+    rescue
+      ArgumentError -> key
+    end
+  end
+
+  defp as_atom(key, true, false) when is_binary(key) do
+    String.to_existing_atom(key)
+  end
+
+  defp as_atom(key, false, _) when is_binary(key) do
+    String.to_atom(key)
+  end
+
+  defp as_atom(key, _, _), do: key
+
+  @spec as_underscore(
+          String.t() | atom(),
+          underscore? :: boolean(),
+          high_perf? :: boolean()
+        ) :: String.t()
+  defp as_underscore(key, true, false) when is_binary(key) do
+    underscore(key)
+  end
+
+  defp as_underscore(key, true, false) when is_atom(key) do
+    key
+    |> Atom.to_string()
+    |> as_underscore(true, false)
+  end
+
+  defp as_underscore(key, true, true) when is_binary(key) do
+    high_perf_underscore(key)
+  end
+
+  defp as_underscore(key, true, true) when is_atom(key) do
+    key
+    |> Atom.to_string()
+    |> as_underscore(true, true)
+  end
+
+  defp as_underscore(key, _, _), do: key
+
+  @spec underscore(atom() | String.t()) :: String.t()
+  defp underscore(key) do
+    key
+    |> Macro.underscore()
+    |> String.replace(~r/-/, "_")
+  end
+
+  @spec high_perf_underscore(String.t() | charlist()) :: String.t() | charlist()
+  defp high_perf_underscore(key) when is_binary(key) do
+    key
+    |> String.to_charlist()
+    |> high_perf_underscore()
+    |> to_string()
+  end
+
+  defp high_perf_underscore([h | t]) do
+    [to_lower_char(h)] ++ to_underscore(t, h)
+  end
+
+  defp high_perf_underscore(~c"") do
+    ~c""
+  end
+
+  @spec to_underscore(charlist(), char()) :: charlist()
+  defp to_underscore([h | t], prev) when prev == ?_ or prev == ?- do
+    [to_lower_char(h)] ++ to_underscore(t, h)
+  end
+
+  defp to_underscore([h0, h1 | t], _prev)
+       when h0 >= ?A and h0 <= ?Z and not (h1 >= ?A and h1 <= ?Z) and h1 != ?_ and h1 != ?- do
+    [?_, to_lower_char(h0), h1] ++ to_underscore(t, h1)
+  end
+
+  defp to_underscore([h | t], prev)
+       when h >= ?A and h <= ?Z and not (prev >= ?A and prev <= ?Z) and prev != ?_ and prev != ?- do
+    [?_, to_lower_char(h)] ++ to_underscore(t, h)
+  end
+
+  defp to_underscore([h | t], _prev) do
+    [to_lower_char(h)] ++ to_underscore(t, h)
+  end
+
+  defp to_underscore(~C"", _h) do
+    ~C""
+  end
+
+  @spec to_lower_char(char()) :: char()
+  defp to_lower_char(?-), do: ?_
+
+  defp to_lower_char(char) when char >= ?A and char <= ?Z do
+    char + 32
+  end
+
+  defp to_lower_char(char) do
+    char
+  end
+end

--- a/lib/open_api_typesense/converter.ex
+++ b/lib/open_api_typesense/converter.ex
@@ -1,4 +1,8 @@
 defmodule OpenApiTypesense.Converter do
+  @moduledoc """
+  Converting your maps/structs that contains string or mix of atom keys into full atom keyed maps.
+  """
+
   defstruct safe: true,
             underscore: true,
             high_perf: false,
@@ -31,11 +35,11 @@ defmodule OpenApiTypesense.Converter do
     |> List.to_tuple()
   end
 
-  def to_atom_keys(val, _opts = %__MODULE__{}) do
+  def to_atom_keys(val, opts = %__MODULE__{}) when is_struct(opts) do
     val
   end
 
-  def to_atom_keys(val, opts = %{}) do
+  def to_atom_keys(val, opts = %{}) when is_map(opts) do
     to_atom_keys(val, struct(__MODULE__, opts))
   end
 
@@ -52,11 +56,9 @@ defmodule OpenApiTypesense.Converter do
   @spec as_atom(String.t() | atom(), safe? :: boolean(), ignore? :: boolean()) ::
           atom() | String.t()
   defp as_atom(key, true, true) when is_binary(key) do
-    try do
-      as_atom(key, true, false)
-    rescue
-      ArgumentError -> key
-    end
+    as_atom(key, true, false)
+  rescue
+    ArgumentError -> key
   end
 
   defp as_atom(key, true, false) when is_binary(key) do


### PR DESCRIPTION
Based on [`to_existing_atom/1`](https://hexdocs.pm/elixir/String.html#to_existing_atom/1):

> [!NOTE]
> Since Elixir is a compiled language, the atoms defined in a module will only exist after said module is loaded, which typically happens whenever a function in the module is executed. Therefore, it is generally recommended to call `String.to_existing_atom/1` only to convert atoms defined within the module making the function call to `to_existing_atom/1`.
>
> To create a module name itself from a string safely, it is recommended to use `Module.safe_concat/1`.

```elixir
iex> _ = :my_atom
iex> String.to_existing_atom("my_atom")
:my_atom
```

> So if a function in `Foo` does a `String.to_existing_atom` expecting to find an atom defined in `Bar`, it could fail if nothing else has yet referenced `Bar`. [source](https://elixirforum.com/t/why-do-atoms-need-to-be-in-the-same-module-for-string-to-existing-atom-1/64208)

### Why raising PR?

E.g. `OpenApiTypesense.AnalyticsRuleSchema` has 3 fields `:name`, `:params`, `:type`:

```elixir
defmodule OpenApiTypesense.AnalyticsRuleSchema do
  ...
  defstruct [:name, :params, :type]
  ...
end
```

Deriving it via Jason.Encoder would mean encoding also the nested data inside of it, just to satisfy checking of dialyzer.

An alternative way instead of json encoding all schemas:

- extract the keys from a specific schema/struct, assuming all are atom keys
- make a copy of that keys, this time string keys
- combine those keys (user might use string or atom or mix of it, that's why)
- remove everything on user's payload that don't match on the combined keys

In order to minimize the creation of unneeded atoms and also act as a guardrails when a user has an arbitrary amount of fields declared in a payload.

Without it, if user accidentally creates a payload with deeply nested fields, there's a possibility of atom exhaustion if left unchecked.

## Summary by Sourcery

Prevent unsafe atom creation by filtering payload keys against struct definitions and using a new Converter module for controlled atom key conversion when parsing JSON content in the client.

Enhancements:
- Introduce OpenApiTypesense.Converter for recursive, configurable atom key conversion with safe and unsafe modes
- Enhance Client.parse_content_type/2 to filter JSON payloads by struct keys and apply safe atom conversion before encoding to prevent unchecked atom creation