### PR TITLE
Add support for v30.1

### DIFF
--- a/.github/workflows/ci_v26.0.yml
+++ b/.github/workflows/ci_v26.0.yml
@@ -21,7 +21,6 @@ jobs:
   # - [actions skip]
 
   test:
-    if: ${{ (github.event_name == 'push' || github.event_name == 'pull_request') && github.repository == 'jaeyson/open_api_typesense' }}
     runs-on: ubuntu-latest
     environment: review
 

--- a/.github/workflows/ci_v26.0.yml
+++ b/.github/workflows/ci_v26.0.yml
@@ -45,10 +45,6 @@ jobs:
           elixir: '1.19'
           lint: false
 
-    services:
-      typesense:
-        image: typesense/typesense:${{ matrix.typesense }}
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/ci_v27.0.yml
+++ b/.github/workflows/ci_v27.0.yml
@@ -21,7 +21,6 @@ jobs:
   # - [actions skip]
 
   test:
-    if: ${{ (github.event_name == 'push' || github.event_name == 'pull_request') && github.repository == 'jaeyson/open_api_typesense' }}
     runs-on: ubuntu-latest
     environment: review
 

--- a/.github/workflows/ci_v27.0.yml
+++ b/.github/workflows/ci_v27.0.yml
@@ -45,10 +45,6 @@ jobs:
           elixir: '1.19'
           lint: false
 
-    services:
-      typesense:
-        image: typesense/typesense:${{ matrix.typesense }}
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/ci_v27.1.yml
+++ b/.github/workflows/ci_v27.1.yml
@@ -21,7 +21,6 @@ jobs:
   # - [actions skip]
 
   test:
-    if: ${{ (github.event_name == 'push' || github.event_name == 'pull_request') && github.repository == 'jaeyson/open_api_typesense' }}
     runs-on: ubuntu-latest
     environment: review
 

--- a/.github/workflows/ci_v27.1.yml
+++ b/.github/workflows/ci_v27.1.yml
@@ -45,10 +45,6 @@ jobs:
           elixir: '1.19'
           lint: false
 
-    services:
-      typesense:
-        image: typesense/typesense:${{ matrix.typesense }}
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/ci_v28.0.yml
+++ b/.github/workflows/ci_v28.0.yml
@@ -21,7 +21,6 @@ jobs:
   # - [actions skip]
 
   test:
-    if: ${{ (github.event_name == 'push' || github.event_name == 'pull_request') && github.repository == 'jaeyson/open_api_typesense' }}
     runs-on: ubuntu-latest
     environment: review
 

--- a/.github/workflows/ci_v28.0.yml
+++ b/.github/workflows/ci_v28.0.yml
@@ -41,10 +41,6 @@ jobs:
           elixir: '1.18'
           lint: false 
 
-    services:
-      typesense:
-        image: typesense/typesense:${{ matrix.typesense }}
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/ci_v29.0.yml
+++ b/.github/workflows/ci_v29.0.yml
@@ -41,10 +41,6 @@ jobs:
           elixir: '1.18'
           lint: false
 
-    services:
-      typesense:
-        image: typesense/typesense:${{ matrix.typesense }}
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/ci_v29.0.yml
+++ b/.github/workflows/ci_v29.0.yml
@@ -21,7 +21,6 @@ jobs:
   # - [actions skip]
 
   test:
-    if: ${{ (github.event_name == 'push' || github.event_name == 'pull_request') && github.repository == 'jaeyson/open_api_typesense' }}
     runs-on: ubuntu-latest
     environment: review
 

--- a/.github/workflows/ci_v30.0.yml
+++ b/.github/workflows/ci_v30.0.yml
@@ -21,7 +21,6 @@ jobs:
   # - [actions skip]
 
   test:
-    if: ${{ (github.event_name == 'push' || github.event_name == 'pull_request') && github.repository == 'jaeyson/open_api_typesense' }}
     runs-on: ubuntu-latest
     environment: review
 
@@ -94,15 +93,12 @@ jobs:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
-      - name: Restore cache
-        id: cache_restore
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
-        if: ${{ matrix.lint }}
+      - name: Cache dependencies/builds
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: |
             deps
             _build
-            priv/plts
           key: ${{ runner.os }}-typesense-${{ matrix.typesense}}-${{ matrix.otp}}-${{ matrix.elixir}}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-typesense-${{ matrix.typesense}}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-
@@ -150,15 +146,3 @@ jobs:
       - name: Post test coverage to Coveralls
         run: mix coveralls.github
         if: ${{ matrix.lint && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-
-      - name: Save cache
-        id: cache_save
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7
-        if: ${{ matrix.lint }}
-        with:
-          path: |
-            deps
-            _build
-            priv/plts
-          key: |
-            ${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}

--- a/.github/workflows/ci_v30.0.yml
+++ b/.github/workflows/ci_v30.0.yml
@@ -41,10 +41,6 @@ jobs:
           elixir: '1.18'
           lint: false
 
-    services:
-      typesense:
-        image: typesense/typesense:${{ matrix.typesense }}
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/ci_v30.0.yml
+++ b/.github/workflows/ci_v30.0.yml
@@ -1,7 +1,6 @@
 name: CI v30.0
 
 on:
-  workflow_call:
   pull_request:
     branches: ["main"]
 
@@ -41,7 +40,7 @@ jobs:
         - typesense: '30.0'
           otp: '28'
           elixir: '1.18'
-          lint: true
+          lint: false
 
     services:
       typesense:

--- a/.github/workflows/ci_v30.1.yml
+++ b/.github/workflows/ci_v30.1.yml
@@ -2,8 +2,6 @@ name: CI v30.1
 
 on:
   workflow_call:
-  pull_request:
-    branches: ["main"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,7 +20,6 @@ jobs:
   # - [actions skip]
 
   test:
-    if: ${{ (github.event_name == 'push' || github.event_name == 'pull_request') && github.repository == 'jaeyson/open_api_typesense' }}
     runs-on: ubuntu-latest
     environment: review
 
@@ -104,7 +101,7 @@ jobs:
             deps
             _build
             priv/plts
-          key: ${{ runner.os }}-typesense-${{ matrix.typesense}}-${{ matrix.otp}}-${{ matrix.elixir}}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-typesense-${{ matrix.typesense }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-typesense-${{ matrix.typesense}}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-
 
@@ -161,5 +158,5 @@ jobs:
             deps
             _build
             priv/plts
-          key: |
-            ${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-typesense-${{ matrix.typesense }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('**/mix.lock') }}
+

--- a/.github/workflows/ci_v30.1.yml
+++ b/.github/workflows/ci_v30.1.yml
@@ -1,6 +1,7 @@
-name: CI v29.0
+name: CI v30.1
 
 on:
+  workflow_call:
   pull_request:
     branches: ["main"]
 
@@ -28,19 +29,19 @@ jobs:
     env:
       MIX_ENV: test
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      LATEST_TYPESENSE: '29.0'
+      LATEST_TYPESENSE: '30.1'
 
     strategy:
       matrix:
         include:
-        - typesense: '29.0'
+        - typesense: '30.1'
           otp: '25'
           elixir: '1.14'
           lint: false
-        - typesense: '29.0'
+        - typesense: '30.1'
           otp: '28'
           elixir: '1.18'
-          lint: false
+          lint: true
 
     services:
       typesense:
@@ -94,12 +95,15 @@ jobs:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
-      - name: Cache dependencies/builds
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+      - name: Restore cache
+        id: cache_restore
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        if: ${{ matrix.lint }}
         with:
           path: |
             deps
             _build
+            priv/plts
           key: ${{ runner.os }}-typesense-${{ matrix.typesense}}-${{ matrix.otp}}-${{ matrix.elixir}}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-typesense-${{ matrix.typesense}}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-
@@ -133,9 +137,29 @@ jobs:
         run: mix format --check-formatted
         if: ${{ matrix.lint }}
 
+      - name: Create PLTs
+        if: ${{ steps.cache_restore.outputs.cache-hit != 'true' && matrix.lint }}
+        run: mix dialyzer --plt
+
+      - name: Dialyzer
+        run: mix dialyzer --format github --format dialyxir
+        if: ${{ matrix.lint }}
+
       - name: Run tests
         run: mix test --only ${{ matrix.typesense }}:true --only nls:true --trace
 
       - name: Post test coverage to Coveralls
         run: mix coveralls.github
         if: ${{ matrix.lint && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+      - name: Save cache
+        id: cache_save
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        if: ${{ matrix.lint }}
+        with:
+          path: |
+            deps
+            _build
+            priv/plts
+          key: |
+            ${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}

--- a/.github/workflows/ci_v30.1.yml
+++ b/.github/workflows/ci_v30.1.yml
@@ -40,10 +40,6 @@ jobs:
           elixir: '1.18'
           lint: true
 
-    services:
-      typesense:
-        image: typesense/typesense:${{ matrix.typesense }}
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/llm.yml
+++ b/.github/workflows/llm.yml
@@ -13,7 +13,6 @@ jobs:
     secrets: inherit
 
   llm:
-    if: ${{ (github.event_name == 'push' || github.event_name == 'pull_request') && github.repository == 'jaeyson/open_api_typesense' }}
     runs-on: ubuntu-latest
     environment: review
     needs: [ci_workflow]

--- a/.github/workflows/llm.yml
+++ b/.github/workflows/llm.yml
@@ -43,10 +43,6 @@ jobs:
           otp: '28'
           elixir: '1.18'
 
-    services:
-      typesense:
-        image: typesense/typesense:${{ matrix.typesense }}
-
     steps:
       - name: Start Typesense
         run: |

--- a/.github/workflows/llm.yml
+++ b/.github/workflows/llm.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   ci_workflow:
-    uses: ./.github/workflows/ci_v30.0.yml
+    uses: ./.github/workflows/ci_v30.1.yml
     secrets: inherit
 
   llm:
@@ -31,15 +31,15 @@ jobs:
         - typesense: '30.0'
           otp: '25'
           elixir: '1.14'
-        - typesense: '29.0'
-          otp: '25'
-          elixir: '1.14'
         - typesense: '30.1'
           otp: '28'
           elixir: '1.18'
         - typesense: '30.0'
           otp: '28'
           elixir: '1.18'
+        - typesense: '29.0'
+          otp: '25'
+          elixir: '1.14'
         - typesense: '29.0'
           otp: '28'
           elixir: '1.18'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## major.minor.patch (yyyy.mm.dd)
 
+## 1.3.0 (2026.04.14)
+
+### Chore
+
+* Support for Typesense v30.1. See <https://typesense.org/docs/30.1/api>
+
 ## 1.2.0 (2026.04.13)
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Restful client for Typesense with adherence to Open API spec 3 (formerly Swagger
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/965dd3f8866d49c3b3e82edd0f6270cb)](https://app.codacy.com/gh/jaeyson/open_api_typesense/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![codescenene Average Code Health](https://codescene.io/projects/63240/status-badges/average-code-health)](https://codescene.io/projects/63240)
 
+[![CI v30.1](https://github.com/jaeyson/open_api_typesense/actions/workflows/ci_v30.1.yml/badge.svg)](https://github.com/jaeyson/open_api_typesense/actions/workflows/ci_v30.1.yml)
 [![CI v30.0](https://github.com/jaeyson/open_api_typesense/actions/workflows/ci_v30.0.yml/badge.svg)](https://github.com/jaeyson/open_api_typesense/actions/workflows/ci_v30.0.yml)
 [![CI v29.0](https://github.com/jaeyson/open_api_typesense/actions/workflows/ci_v29.0.yml/badge.svg)](https://github.com/jaeyson/open_api_typesense/actions/workflows/ci_v29.0.yml)
 [![CI v28.0](https://github.com/jaeyson/open_api_typesense/actions/workflows/ci_v28.0.yml/badge.svg)](https://github.com/jaeyson/open_api_typesense/actions/workflows/ci_v28.0.yml)
@@ -17,7 +18,7 @@ Restful client for Typesense with adherence to Open API spec 3 (formerly Swagger
 
 [![Dependabot](https://img.shields.io/badge/Dependabot-enabled-green)](https://github.com/jaeyson/open_api_typesense/pulls/app%2Fdependabot)
 [![Hex.pm](https://img.shields.io/hexpm/l/open_api_typesense)](https://hexdocs.pm/open_api_typesense/license.html)
-[![Latest Typesense compatible](https://img.shields.io/badge/Latest%20Typesense%20compatible-v30.0-%230F35BC)](https://typesense.org/docs/30.0/api)
+[![Latest Typesense compatible](https://img.shields.io/badge/Latest%20Typesense%20compatible-v30.1-%230F35BC)](https://typesense.org/docs/30.1/api)
 
 **Note**: the only place where ai is used/integrated is in PR reviews. I am NOT interested in adding/integrating ai generated code in this codebase, as this little library can be fit in my mental model. ai has it’s own great use case, it’s just that I wanted to be hands-on with these projects.
 
@@ -48,7 +49,7 @@ by adding `open_api_typesense` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:open_api_typesense, "~> 1.2"}
+    {:open_api_typesense, "~> 1.3"}
 
     # Or from GitHub repository, if you want the latest greatest from main branch
     {:open_api_typesense, git: "https://github.com/jaeyson/open_api_typesense.git"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   typesense:
-    image: docker.io/typesense/typesense:29.0
+    image: docker.io/typesense/typesense:30.1
     container_name: typesense
     restart: on-failure
     ports:

--- a/lib/open_api_typesense/operations/analytics.ex
+++ b/lib/open_api_typesense/operations/analytics.ex
@@ -290,7 +290,9 @@ defmodule OpenApiTypesense.Analytics do
           body :: OpenApiTypesense.AnalyticsRuleUpdate.t(),
           opts :: keyword
         ) ::
-          {:ok, OpenApiTypesense.AnalyticsRule.t()} | {:error, OpenApiTypesense.ApiResponse.t()}
+          {:ok, OpenApiTypesense.AnalyticsRule.t()}
+          | {:ok, OpenApiTypesense.AnalyticsRuleSchema.t()}
+          | {:error, OpenApiTypesense.ApiResponse.t()}
   def upsert_analytics_rule(rule_name, body, opts \\ []) do
     client = opts[:client] || @default_client
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule OpenApiTypesense.MixProject do
 
   @source_url "https://github.com/jaeyson/open_api_typesense"
   @hex_url "https://hexdocs.pm/open_api_typesense"
-  @version "1.2.0"
+  @version "1.3.0"
 
   def project do
     [

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -11,7 +11,15 @@ defmodule ConnectionTest do
     message: "Forbidden - a valid `x-typesense-api-key` header must be sent."
   }
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "new/0 using the default config to creates a connection struct" do
     assert Connection.new() === %Connection{
              api_key: "xyz",
@@ -25,7 +33,15 @@ defmodule ConnectionTest do
            }
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "new/1 with custom fields creates a connection struct" do
     conn =
       Connection.new(%{
@@ -47,7 +63,15 @@ defmodule ConnectionTest do
            }
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: wrong api key was configured" do
     conn = %{
       host: "localhost",
@@ -59,7 +83,15 @@ defmodule ConnectionTest do
     assert {:error, @forbidden} == Collections.get_collections(conn: conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: overriding config with a wrong API key" do
     conn = %{
       host: "localhost",
@@ -71,34 +103,74 @@ defmodule ConnectionTest do
     assert {:error, @forbidden} = Collections.get_collections(conn: conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: health check, with incorrect port number" do
     conn = %{api_key: "xyz", host: "localhost", port: 8100, scheme: "http"}
 
     assert {:error, "connection refused"} = Health.health(conn: conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: health check, with incorrect host" do
     conn = %{api_key: "xyz", host: "my_test_host", port: 8108, scheme: "http"}
 
     assert {:error, "non-existing domain"} = Health.health(conn: conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "new/1 with Connection struct" do
     conn = Connection.new()
     assert %Connection{} = Connection.new(conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "new/1 with empty map raises ArgumentError" do
     error = assert_raise ArgumentError, fn -> Connection.new(%{}) end
 
     assert error.message === "Missing required fields: [:api_key, :host, :port, :scheme]"
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "new/1 with invalid data type raises ArgumentError" do
     invalid_inputs = [
       nil,

--- a/test/custom_client_test.exs
+++ b/test/custom_client_test.exs
@@ -74,7 +74,15 @@ defmodule CustomClientTest do
     end)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "returns the configured options" do
     Application.put_env(:open_api_typesense, :options,
       finch: MyApp.CustomFinch,
@@ -86,7 +94,15 @@ defmodule CustomClientTest do
     assert options === [finch: MyApp.CustomFinch, receive_timeout: 5_000]
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "returns an empty map if options is not configured" do
     Application.delete_env(:open_api_typesense, :options)
 
@@ -95,7 +111,15 @@ defmodule CustomClientTest do
     assert options === nil
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "use another HTTP client" do
     map_conn = %{
       api_key: "xyz",

--- a/test/default_client_test.exs
+++ b/test/default_client_test.exs
@@ -7,7 +7,15 @@ defmodule DefaultClientTest do
   require Logger
 
   describe "request/2" do
-    @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+    @tag [
+      "30.1": true,
+      "30.0": true,
+      "29.0": true,
+      "28.0": true,
+      "27.1": true,
+      "27.0": true,
+      "26.0": true
+    ]
     test "default to req http client if no custom client set" do
       conn = Connection.new()
 
@@ -27,7 +35,15 @@ defmodule DefaultClientTest do
   end
 
   describe "build_req_client/2" do
-    @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+    @tag [
+      "30.1": true,
+      "30.0": true,
+      "29.0": true,
+      "28.0": true,
+      "27.1": true,
+      "27.0": true,
+      "26.0": true
+    ]
     test "override req options through req field" do
       req =
         Client.build_req_client(Connection.new(),
@@ -43,7 +59,15 @@ defmodule DefaultClientTest do
     end
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "get api key" do
     assert "xyz" = Client.api_key()
   end

--- a/test/operations/analytics_test.exs
+++ b/test/operations/analytics_test.exs
@@ -79,7 +79,7 @@ defmodule AnalyticsTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): create analytics rule with non-existent collection", %{
     conn: conn,
     map_conn: map_conn
@@ -137,7 +137,7 @@ defmodule AnalyticsTest do
     assert ^error = Analytics.create_analytics_rule(body, conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success (v30.0): upsert analytics rule", %{conn: conn, map_conn: map_conn} do
     name = "product_no_hits"
 
@@ -219,7 +219,15 @@ defmodule AnalyticsTest do
     assert {:error, %ApiResponse{message: _}} = Analytics.create_analytics_rule(body)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: list analytics rules", %{conn: conn, map_conn: map_conn} do
     assert {:ok, rules} = Analytics.retrieve_analytics_rules()
 
@@ -228,7 +236,7 @@ defmodule AnalyticsTest do
     assert {:ok, ^rules} = Analytics.retrieve_analytics_rules(conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success (v30.0): flush analytics", %{conn: conn, map_conn: map_conn} do
     response = {:ok, %AnalyticsEventCreateResponse{ok: true}}
 
@@ -248,7 +256,7 @@ defmodule AnalyticsTest do
     assert ^reason = Analytics.flush_analytics(map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): get analytics events", %{conn: conn, map_conn: map_conn} do
     reason = {:error, %ApiResponse{message: "Rule not found"}}
 
@@ -278,7 +286,7 @@ defmodule AnalyticsTest do
     assert ^reason = Analytics.get_analytics_events(map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success (v30.0): get analytics status", %{conn: conn, map_conn: map_conn} do
     status = %AnalyticsStatus{
       doc_counter_events: 0,
@@ -306,7 +314,7 @@ defmodule AnalyticsTest do
     assert ^reason = Analytics.get_analytics_status(map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success (v30.0): send click events", %{conn: conn, map_conn: map_conn} do
     name = "products_clicks"
 

--- a/test/operations/collections_test.exs
+++ b/test/operations/collections_test.exs
@@ -32,7 +32,15 @@ defmodule CollectionsTest do
     %{schema: schema, alias_name: "foo_bar", conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: clone a collection schema" do
     schema = %{
       "name" => "vehicles",
@@ -56,7 +64,15 @@ defmodule CollectionsTest do
     assert {:ok, _} = Collections.delete_collection(payload["name"])
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: create a collection", %{schema: schema, conn: conn, map_conn: map_conn} do
     name = schema["name"]
 
@@ -72,7 +88,15 @@ defmodule CollectionsTest do
              Collections.get_collections()
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: list collections", %{conn: conn, map_conn: map_conn} do
     assert {:ok, collections} = Collections.get_collections()
 
@@ -86,7 +110,15 @@ defmodule CollectionsTest do
     assert {:ok, _} = Collections.get_collections(conn: map_conn, limit: 1)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: update an existing collection", %{conn: conn, map_conn: map_conn} do
     name = "burgers"
 
@@ -119,7 +151,15 @@ defmodule CollectionsTest do
     Collections.delete_collection(name)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: list empty aliases", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %CollectionAliasesResponse{aliases: aliases}} = Collections.get_aliases()
 
@@ -132,7 +172,15 @@ defmodule CollectionsTest do
              Collections.get_aliases(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: delete a missing collection", %{conn: conn, map_conn: map_conn} do
     error = {:error, %ApiResponse{message: "No collection with name `xyz` found."}}
 
@@ -142,7 +190,15 @@ defmodule CollectionsTest do
     assert ^error = Collections.delete_collection("xyz", conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: upsert an alias", %{
     schema: schema,
     alias_name: alias_name,
@@ -178,7 +234,7 @@ defmodule CollectionsTest do
     assert {:error, %ApiResponse{message: _}} = Collections.get_alias("xyz", conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true]
+  @tag ["30.1": true, "30.0": true, "29.0": true]
   test "error (v28.0): get a non-existing alias", %{conn: conn, map_conn: map_conn} do
     assert Collections.get_alias("non-existing-alias") ==
              {:error, %ApiResponse{message: "Collection not found"}}
@@ -199,7 +255,7 @@ defmodule CollectionsTest do
     assert {:error, %ApiResponse{message: _}} = Collections.get_collection("xyz", conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true]
+  @tag ["30.1": true, "30.0": true, "29.0": true]
   test "error (v28.0): get a non-existing collection", %{conn: conn, map_conn: map_conn} do
     assert Collections.get_collection("non-existing-collection") ==
              {:error, %ApiResponse{message: "Collection not found"}}

--- a/test/operations/conversations_test.exs
+++ b/test/operations/conversations_test.exs
@@ -34,7 +34,15 @@ defmodule ConversationsTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: list conversation models", %{conn: conn, map_conn: map_conn} do
     assert {:ok, models} = Conversations.retrieve_all_conversation_models()
 
@@ -43,7 +51,15 @@ defmodule ConversationsTest do
     assert {:ok, ^models} = Conversations.retrieve_all_conversation_models(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: get a non-existent conversation model", %{conn: conn, map_conn: map_conn} do
     assert {:error, %ApiResponse{message: "Model not found"}} =
              Conversations.retrieve_conversation_model("non-existent")
@@ -53,7 +69,15 @@ defmodule ConversationsTest do
     assert {:error, _} = Conversations.retrieve_conversation_model("xyz", conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: delete a conversation model", %{conn: conn, map_conn: map_conn} do
     assert {:error, %ApiResponse{message: "Model not found"}} =
              Conversations.delete_conversation_model("non-existent")
@@ -63,7 +87,15 @@ defmodule ConversationsTest do
     assert {:error, _} = Conversations.delete_conversation_model("xyz", conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: create a conversation model with incorrect API key", %{
     conn: conn,
     map_conn: map_conn
@@ -95,7 +127,15 @@ defmodule ConversationsTest do
     assert {:error, _} = Conversations.create_conversation_model(body, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: update a conversation model with incorrect API key", %{
     conn: conn,
     map_conn: map_conn

--- a/test/operations/curation_sets_test.exs
+++ b/test/operations/curation_sets_test.exs
@@ -33,7 +33,7 @@ defmodule OpenApiTypesense.CurationSetsTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: retrieve a curation set", %{conn: conn, map_conn: map_conn} do
     name = "curate_catalog"
 
@@ -69,7 +69,7 @@ defmodule OpenApiTypesense.CurationSetsTest do
              CurationSets.retrieve_curation_set(name, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error: retrieve a non-existing curation set", %{conn: conn, map_conn: map_conn} do
     set_name = "unkown-set"
     error = {:error, %ApiResponse{message: "Curation index not found"}}
@@ -79,7 +79,7 @@ defmodule OpenApiTypesense.CurationSetsTest do
     assert ^error = CurationSets.retrieve_curation_set(set_name, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error: retrieve a non-existing curation set item", %{conn: conn, map_conn: map_conn} do
     name = "curate_products_error"
 
@@ -113,7 +113,7 @@ defmodule OpenApiTypesense.CurationSetsTest do
     assert ^error = CurationSets.retrieve_curation_set_item(name, item_id, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error: retrieving an item_id with a whitespace on its name", %{
     conn: conn,
     map_conn: map_conn
@@ -130,7 +130,7 @@ defmodule OpenApiTypesense.CurationSetsTest do
     assert ^error = CurationSets.retrieve_curation_set_item(set_name, item_id, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: list all curation sets", %{conn: conn, map_conn: map_conn} do
     name = "curate_products"
 
@@ -163,7 +163,7 @@ defmodule OpenApiTypesense.CurationSetsTest do
     assert {:ok, _} = CurationSets.retrieve_curation_sets(map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: list all curation set items", %{conn: conn, map_conn: map_conn} do
     set_name = "curate_products"
 
@@ -213,7 +213,7 @@ defmodule OpenApiTypesense.CurationSetsTest do
              CurationSets.retrieve_curation_set_items(set_name, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: create or update a curation set", %{conn: conn, map_conn: map_conn} do
     name = "curate_products"
 
@@ -249,7 +249,7 @@ defmodule OpenApiTypesense.CurationSetsTest do
              CurationSets.upsert_curation_set(name, curation_set, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: upsert a curation set item", %{conn: conn, map_conn: map_conn} do
     set_name = "curate_products"
 
@@ -300,7 +300,7 @@ defmodule OpenApiTypesense.CurationSetsTest do
              CurationSets.upsert_curation_set_item(set_name, item_id, body, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: delete a curation set", %{conn: conn, map_conn: map_conn} do
     name = "curate_products_delete"
 
@@ -334,7 +334,7 @@ defmodule OpenApiTypesense.CurationSetsTest do
     assert ^error = CurationSets.delete_curation_set(name, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: delete a curation set item", %{conn: conn, map_conn: map_conn} do
     name = "curate_products_item"
 

--- a/test/operations/curation_test.exs
+++ b/test/operations/curation_test.exs
@@ -34,7 +34,7 @@ defmodule CurationTest do
     %{schema_name: name, conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for upsert search override", %{
     schema_name: schema_name
   } do
@@ -92,7 +92,7 @@ defmodule CurationTest do
              Curation.upsert_search_override(schema_name, override_id, body, conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for delete search override", %{
     schema_name: schema_name
   } do
@@ -118,7 +118,7 @@ defmodule CurationTest do
     assert {:error, _} = Curation.delete_search_override(schema_name, "test", conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for list collection overrides", %{
     schema_name: schema_name
   } do

--- a/test/operations/debug_test.exs
+++ b/test/operations/debug_test.exs
@@ -12,7 +12,15 @@ defmodule DebugTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: list stopwords sets", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %{"state" => 1, "version" => _}} = Debug.debug()
     assert {:ok, %{"state" => 1, "version" => _}} = Debug.debug([])
@@ -20,7 +28,15 @@ defmodule DebugTest do
     assert {:ok, %{"state" => 1, "version" => _}} = Debug.debug(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "field" do
     assert [version: :string] = Debug.__fields__(:debug_200_json_resp)
   end

--- a/test/operations/documents_test.exs
+++ b/test/operations/documents_test.exs
@@ -38,7 +38,15 @@ defmodule DocumentsTest do
     %{coll_name: name, conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: update a document", %{coll_name: coll_name} do
     body = %{
       "shoes_id" => 12_299,
@@ -57,7 +65,15 @@ defmodule DocumentsTest do
              Documents.update_document(coll_name, document_id, body)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: update a non-existent document", %{
     coll_name: coll_name,
     conn: conn,
@@ -81,7 +97,15 @@ defmodule DocumentsTest do
     assert {:error, _} = Documents.update_document(coll_name, document_id, body, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: search a document", %{coll_name: coll_name, conn: conn, map_conn: map_conn} do
     body =
       [
@@ -123,7 +147,15 @@ defmodule DocumentsTest do
     assert {:ok, _} = Documents.search_collection(coll_name, List.flatten([conn: map_conn], opts))
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: update non-existent documents", %{
     coll_name: coll_name,
     conn: conn,
@@ -145,7 +177,15 @@ defmodule DocumentsTest do
     assert {:ok, _} = Documents.import_documents(coll_name, body, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: multi-search with no documents", %{conn: conn, map_conn: map_conn} do
     body =
       %{
@@ -170,7 +210,15 @@ defmodule DocumentsTest do
     assert {:ok, _} = Documents.multi_search(body, List.flatten([conn: map_conn], params))
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: update documents by query", %{
     coll_name: coll_name,
     conn: conn,
@@ -229,7 +277,15 @@ defmodule DocumentsTest do
              )
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: importing empty documents", %{coll_name: coll_name} do
     assert {:ok, ""} = Documents.import_documents(coll_name, [])
 
@@ -240,7 +296,15 @@ defmodule DocumentsTest do
              Documents.import_documents(coll_name, [%{}])
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: import documents where payload is JSONL", %{coll_name: coll_name} do
     body =
       [
@@ -276,7 +340,15 @@ defmodule DocumentsTest do
     assert {:ok, _} = Documents.import_documents(coll_name, body)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: import documents", %{coll_name: coll_name} do
     body =
       [
@@ -311,7 +383,15 @@ defmodule DocumentsTest do
     assert {:ok, _} = Documents.import_documents(coll_name, body, action: "create")
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: index a document", %{coll_name: coll_name, conn: conn, map_conn: map_conn} do
     shoes_id = 220
 
@@ -335,7 +415,7 @@ defmodule DocumentsTest do
     assert {:ok, _} = Documents.index_document(coll_name, body, conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for list collection overrides" do
     assert {:error, %ApiResponse{message: "Not Found"}} =
              Documents.get_search_overrides("wrong_collection")
@@ -360,7 +440,15 @@ defmodule DocumentsTest do
     assert {:error, _} = Documents.get_search_overrides("xyz", conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: get a non-existent override", %{
     coll_name: coll_name,
     conn: conn,
@@ -374,7 +462,7 @@ defmodule DocumentsTest do
     assert {:error, _} = Documents.get_search_override(coll_name, "xyz", conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for delete a non-existent override", %{
     coll_name: coll_name
   } do
@@ -396,7 +484,15 @@ defmodule DocumentsTest do
     assert {:error, _} = Documents.delete_search_override(coll_name, "xyz", conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: delete a document", %{coll_name: coll_name, conn: conn, map_conn: map_conn} do
     shoes_id = 420
 
@@ -428,7 +524,15 @@ defmodule DocumentsTest do
     assert {:error, _} = Documents.delete_document(coll_name, id, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: delete all documents", %{coll_name: coll_name, conn: conn, map_conn: map_conn} do
     body =
       [
@@ -477,7 +581,15 @@ defmodule DocumentsTest do
              Documents.delete_documents(coll_name, List.flatten([conn: map_conn], opts))
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: get a non-existent document", %{
     coll_name: coll_name,
     conn: conn,
@@ -494,7 +606,15 @@ defmodule DocumentsTest do
     assert {:error, _} = Documents.get_document(coll_name, document_id, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: export document from a non-existent collection", %{conn: conn, map_conn: map_conn} do
     opts = [exclude_fields: "fields"]
 
@@ -508,7 +628,7 @@ defmodule DocumentsTest do
     assert {:error, _} = Documents.export_documents("xyz", List.flatten([conn: map_conn], opts))
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for upsert a search override", %{coll_name: coll_name} do
     body =
       %{
@@ -562,7 +682,15 @@ defmodule DocumentsTest do
              Documents.upsert_search_override(coll_name, "customize-apple", body, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "field" do
     assert [num_deleted: :integer] = Documents.__fields__(:delete_documents_200_json_resp)
     assert [num_updated: :integer] = Documents.__fields__(:update_documents_200_json_resp)

--- a/test/operations/health_test.exs
+++ b/test/operations/health_test.exs
@@ -12,7 +12,15 @@ defmodule HealthTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: health check", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %HealthStatus{ok: true}} = Health.health()
     assert {:ok, %HealthStatus{ok: true}} = Health.health([])
@@ -20,7 +28,15 @@ defmodule HealthTest do
     assert {:ok, %HealthStatus{ok: true}} = Health.health(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: health check error" do
     conn =
       Connection.new(%{
@@ -38,7 +54,15 @@ defmodule HealthTest do
            ]) === true
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: health check connection refused" do
     conn =
       Connection.new(%{
@@ -51,7 +75,15 @@ defmodule HealthTest do
     assert {:error, "connection refused"} = Health.health(conn: conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "error: health check non-existing domain" do
     conn = %{
       api_key: "wrong_key",

--- a/test/operations/join_test.exs
+++ b/test/operations/join_test.exs
@@ -345,7 +345,15 @@ defmodule JoinTest do
     :ok
   end
 
-  @tag ["29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: one-to-one relation" do
     searches = %{
       searches: [
@@ -378,7 +386,15 @@ defmodule JoinTest do
             }} = Documents.multi_search(searches)
   end
 
-  @tag ["29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: one-to-many relation (simple)" do
     searches = %{
       searches: [
@@ -436,7 +452,15 @@ defmodule JoinTest do
             }} = Documents.multi_search(searches)
   end
 
-  @tag ["29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: one-to-many relation (specialized)" do
     searches = %{
       searches: [
@@ -473,7 +497,15 @@ defmodule JoinTest do
             }} = Documents.multi_search(searches)
   end
 
-  @tag ["29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: merging or nesting joined fields" do
     searches = %{
       searches: [
@@ -514,7 +546,15 @@ defmodule JoinTest do
             }} = Documents.multi_search(searches)
   end
 
-  @tag ["29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: forcing nested array for joined fields" do
     searches = %{
       searches: [
@@ -551,7 +591,15 @@ defmodule JoinTest do
             }} = Documents.multi_search(searches)
   end
 
-  @tag ["29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: left join" do
     opts = [
       collection: "authors",
@@ -576,7 +624,15 @@ defmodule JoinTest do
             }} = Documents.search_collection("authors", opts)
   end
 
-  @tag ["29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: nested joins" do
     opts = [
       q: "shampoo",
@@ -633,7 +689,15 @@ defmodule JoinTest do
             }} = Documents.search_collection("join_products", opts)
   end
 
-  @tag ["29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: nested joins (geo radius)" do
     opts = [
       q: "shampoo",

--- a/test/operations/keys_test.exs
+++ b/test/operations/keys_test.exs
@@ -29,7 +29,15 @@ defmodule KeysTest do
     %{api_key_schema: api_key_schema, conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: get a specific key", %{
     api_key_schema: api_key_schema,
     conn: conn,
@@ -45,7 +53,15 @@ defmodule KeysTest do
     assert {:ok, %ApiKey{id: ^key_id}} = Keys.get_key(key_id, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: list API keys", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %ApiKeysResponse{keys: keys}} = Keys.get_keys()
 
@@ -54,7 +70,15 @@ defmodule KeysTest do
     assert {:ok, %ApiKeysResponse{keys: ^keys}} = Keys.get_keys(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: delete an API key", %{
     api_key_schema: api_key_schema,
     conn: conn,
@@ -70,7 +94,15 @@ defmodule KeysTest do
     assert {:error, _} = Keys.delete_key(key_id, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: create an search-only API key", %{
     api_key_schema: api_key_schema,
     conn: conn,
@@ -82,7 +114,15 @@ defmodule KeysTest do
     assert {:ok, %ApiKey{}} = Keys.create_key(api_key_schema, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: create an admin API key", %{api_key_schema: api_key_schema} do
     body =
       api_key_schema

--- a/test/operations/operations_test.exs
+++ b/test/operations/operations_test.exs
@@ -16,7 +16,15 @@ defmodule OperationsTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: retrieve api stats", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %APIStatsResponse{}} = Operations.retrieve_api_stats()
     assert {:ok, %APIStatsResponse{}} = Operations.retrieve_api_stats([])
@@ -24,7 +32,15 @@ defmodule OperationsTest do
     assert {:ok, %APIStatsResponse{}} = Operations.retrieve_api_stats(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: retrieve metrics", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %{system_cpu_active_percentage: _}} = Operations.retrieve_metrics()
     assert {:ok, %{system_cpu_active_percentage: _}} = Operations.retrieve_metrics([])
@@ -32,7 +48,15 @@ defmodule OperationsTest do
     assert {:ok, %{system_cpu_active_percentage: _}} = Operations.retrieve_metrics(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: toggle threshold time for request log", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %SuccessStatus{success: true}} =
              Operations.toggle_slow_request_log(%{"log-slow-requests-time-ms" => 2_000})
@@ -47,7 +71,15 @@ defmodule OperationsTest do
              Operations.toggle_slow_request_log(body, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: clear cache", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %SuccessStatus{success: true}} = Operations.clear_cache()
     assert {:ok, %SuccessStatus{success: true}} = Operations.clear_cache([])
@@ -55,7 +87,15 @@ defmodule OperationsTest do
     assert {:ok, %SuccessStatus{success: true}} = Operations.clear_cache(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: compact database", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %SuccessStatus{success: true}} = Operations.compact_db()
     assert {:ok, %SuccessStatus{success: true}} = Operations.compact_db([])
@@ -63,7 +103,15 @@ defmodule OperationsTest do
     assert {:ok, %SuccessStatus{success: true}} = Operations.compact_db(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: take snapshot", %{conn: conn, map_conn: map_conn} do
     # we have to add sleep timer for github actions
     # otherwise it will return like:
@@ -87,7 +135,15 @@ defmodule OperationsTest do
              Operations.take_snapshot(List.flatten([conn: map_conn], params))
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: re-elect leader", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %SuccessStatus{success: false}} = Operations.vote()
     assert {:ok, %SuccessStatus{success: false}} = Operations.vote([])
@@ -95,7 +151,15 @@ defmodule OperationsTest do
     assert {:ok, %SuccessStatus{success: false}} = Operations.vote(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": false, "27.0": false, "26.0": false]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": false,
+    "27.0": false,
+    "26.0": false
+  ]
   test "success: (v28.0) get schema changes", %{conn: conn, map_conn: map_conn} do
     assert {:ok, schemas} = Operations.get_schema_changes()
 

--- a/test/operations/override_test.exs
+++ b/test/operations/override_test.exs
@@ -12,7 +12,7 @@ defmodule OverrideTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag ["30.1": true, "30.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
   test "error: retrieve an override", %{conn: conn, map_conn: map_conn} do
     error = {:error, %ApiResponse{message: "Not Found"}}
 

--- a/test/operations/presets_test.exs
+++ b/test/operations/presets_test.exs
@@ -33,7 +33,15 @@ defmodule PresetsTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: list presets", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %PresetsRetrieveSchema{presets: presets}} = Presets.retrieve_all_presets()
     refute Enum.empty?(presets)
@@ -43,7 +51,15 @@ defmodule PresetsTest do
     assert {:ok, _} = Presets.retrieve_all_presets(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: get a preset", %{conn: conn, map_conn: map_conn} do
     assert {:error, %ApiResponse{message: "Not found."}} = Presets.retrieve_preset("listing_view")
     assert {:error, _} = Presets.retrieve_preset("listing_view", [])
@@ -51,7 +67,15 @@ defmodule PresetsTest do
     assert {:error, _} = Presets.retrieve_preset("listing_view", conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: upsert a preset", %{conn: conn, map_conn: map_conn} do
     body =
       %{
@@ -70,7 +94,15 @@ defmodule PresetsTest do
     assert {:ok, _} = Presets.upsert_preset("restaurant_view", body, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: delete a preset", %{conn: conn, map_conn: map_conn} do
     body =
       %{

--- a/test/operations/stemming_test.exs
+++ b/test/operations/stemming_test.exs
@@ -32,7 +32,15 @@ defmodule StemmingTest do
     %{id: id, conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": false, "27.0": false, "26.0": false]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": false,
+    "27.0": false,
+    "26.0": false
+  ]
   test "success: create stemming dictionaries", %{conn: conn, map_conn: map_conn} do
     id = "example-stemming"
 
@@ -64,7 +72,15 @@ defmodule StemmingTest do
             ]} = Stemming.import_stemming_dictionary(body, id: id, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": false, "27.0": false, "26.0": false]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": false,
+    "27.0": false,
+    "26.0": false
+  ]
   test "success: list stemming dictionaries", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %{"dictionaries" => _}} = Stemming.list_stemming_dictionaries()
     assert {:ok, %{"dictionaries" => _}} = Stemming.list_stemming_dictionaries([])
@@ -72,13 +88,21 @@ defmodule StemmingTest do
     assert {:ok, %{"dictionaries" => _}} = Stemming.list_stemming_dictionaries(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": false, "27.1": false, "27.0": false, "26.0": false]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": false,
+    "27.1": false,
+    "27.0": false,
+    "26.0": false
+  ]
   test "error: (v29.0) non-existent stemming dictionary" do
     assert {:error, %ApiResponse{message: "Collection not found"}} =
              Stemming.get_stemming_dictionary("non-existent")
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error: (v30.0) non-existent stemming dictionary" do
     assert {:error, %ApiResponse{message: "Collection not found"}} =
              Stemming.get_stemming_dictionary("non-existent")
@@ -90,7 +114,15 @@ defmodule StemmingTest do
              Stemming.get_stemming_dictionary("non-existent")
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": false, "27.0": false, "26.0": false]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": false,
+    "27.0": false,
+    "26.0": false
+  ]
   test "success: get specific stemming dictionary", %{id: id, conn: conn, map_conn: map_conn} do
     body = [
       %{"word" => "mice", "root" => "mouse"},
@@ -113,7 +145,15 @@ defmodule StemmingTest do
              Stemming.get_stemming_dictionary(id, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": false, "27.0": false, "26.0": false]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": false,
+    "27.0": false,
+    "26.0": false
+  ]
   test "field" do
     assert [dictionaries: [:string]] =
              Stemming.__fields__(:list_stemming_dictionaries_200_json_resp)

--- a/test/operations/stopwords_test.exs
+++ b/test/operations/stopwords_test.exs
@@ -25,7 +25,15 @@ defmodule StopwordsTest do
     %{conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: list stopwords sets", %{conn: conn, map_conn: map_conn} do
     assert {:ok, %StopwordsSetsRetrieveAllSchema{stopwords: _stopwords}} =
              Stopwords.retrieve_stopwords_sets()
@@ -35,7 +43,15 @@ defmodule StopwordsTest do
     assert {:ok, _} = Stopwords.retrieve_stopwords_sets(conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: add stopwords", %{conn: conn, map_conn: map_conn} do
     set_id = "stopword_set_countries"
 
@@ -51,7 +67,15 @@ defmodule StopwordsTest do
     assert {:ok, _} = Stopwords.upsert_stopwords_set(set_id, body, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: retrieve specific stopwords set", %{conn: conn, map_conn: map_conn} do
     set_id = "stopword_set_names"
 
@@ -76,7 +100,15 @@ defmodule StopwordsTest do
              Stopwords.retrieve_stopwords_set(set_id, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "success: delete specific stopwords set", %{conn: conn, map_conn: map_conn} do
     set_id = "stopword_set_companies"
 
@@ -95,7 +127,15 @@ defmodule StopwordsTest do
     assert {:error, ^reason} = Stopwords.delete_stopwords_set(set_id, conn: map_conn)
   end
 
-  @tag ["30.0": true, "29.0": true, "28.0": true, "27.1": true, "27.0": true, "26.0": true]
+  @tag [
+    "30.1": true,
+    "30.0": true,
+    "29.0": true,
+    "28.0": true,
+    "27.1": true,
+    "27.0": true,
+    "26.0": true
+  ]
   test "field" do
     assert [id: :string] = Stopwords.__fields__(:delete_stopwords_set_200_json_resp)
   end

--- a/test/operations/synonyms_test.exs
+++ b/test/operations/synonyms_test.exs
@@ -52,7 +52,7 @@ defmodule SynonymsTest do
     %{coll_name: collection_name, conn: conn, map_conn: map_conn}
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for list collection synonyms", %{coll_name: coll_name} do
     error = {:error, %ApiResponse{message: "Not Found"}}
     assert ^error = Synonyms.get_search_synonyms(coll_name)
@@ -77,7 +77,7 @@ defmodule SynonymsTest do
              Synonyms.get_search_synonyms(coll_name, conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for upsert a collection synonym", %{
     coll_name: coll_name
   } do
@@ -115,7 +115,7 @@ defmodule SynonymsTest do
     assert {:ok, _} = Synonyms.upsert_search_synonym(coll_name, synonym_id, body, conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for delete a collection synonym", %{
     coll_name: coll_name
   } do
@@ -154,7 +154,7 @@ defmodule SynonymsTest do
     assert {:error, _} = Synonyms.delete_search_synonym(coll_name, synonym_id, conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: delete a synonym set item", %{conn: conn, map_conn: map_conn} do
     name = "tech-synonyms"
 
@@ -189,7 +189,7 @@ defmodule SynonymsTest do
     assert ^error = Synonyms.delete_synonym_set_item(name, item_id, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecate function delete a synonym associated with a collection", %{
     coll_name: coll_name
   } do
@@ -198,7 +198,7 @@ defmodule SynonymsTest do
     assert ^error = Synonyms.delete_search_synonym(coll_name, synonym_id)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: list all synonym sets", %{conn: conn, map_conn: map_conn} do
     name = "sample"
 
@@ -220,7 +220,7 @@ defmodule SynonymsTest do
     assert {:ok, _} = Synonyms.retrieve_synonym_sets(map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: retrieve a synonym set", %{conn: conn, map_conn: map_conn} do
     name = "sample"
 
@@ -242,7 +242,7 @@ defmodule SynonymsTest do
              Synonyms.retrieve_synonym_set(name, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: retrieve a synonym set item", %{conn: conn, map_conn: map_conn} do
     name = "tech-synonyms"
 
@@ -281,7 +281,7 @@ defmodule SynonymsTest do
              Synonyms.retrieve_synonym_set_item(name, item_id, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: retrieve a synonym set items", %{conn: conn, map_conn: map_conn} do
     name = "tech-synonyms"
 
@@ -314,7 +314,7 @@ defmodule SynonymsTest do
     assert {:ok, _} = Synonyms.retrieve_synonym_set_items(name, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "error (v30.0): deprecated function for get a collection synonym", %{coll_name: coll_name} do
     synonym_id = "t-shirt-synonyms"
     error = {:error, %ApiResponse{message: "Not Found"}}
@@ -346,7 +346,7 @@ defmodule SynonymsTest do
     assert {:ok, _} = Synonyms.get_search_synonym(coll_name, synonym_id, conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: create or update a synonym set (multi-way synonym)", %{
     conn: conn,
     map_conn: map_conn
@@ -372,7 +372,7 @@ defmodule SynonymsTest do
              Synonyms.upsert_synonym_set(name, body, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: create or update a synonym set (one-way synonym)", %{
     conn: conn,
     map_conn: map_conn
@@ -399,7 +399,7 @@ defmodule SynonymsTest do
              Synonyms.upsert_synonym_set(name, body, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: upsert a synonym set item", %{conn: conn, map_conn: map_conn} do
     name = "tech-synonyms"
 
@@ -435,7 +435,7 @@ defmodule SynonymsTest do
              Synonyms.upsert_synonym_set_item(name, item_id, body, map_conn: map_conn)
   end
 
-  @tag ["30.0": true]
+  @tag ["30.1": true, "30.0": true]
   test "success: delete a synonym set", %{conn: conn, map_conn: map_conn} do
     name = "tech-synonyms"
 


### PR DESCRIPTION
Closes #44

## Summary by Sourcery

Add support for Typesense server version 30.1 across tests, CI, and local development, including minor API typing adjustment for analytics rules.

Enhancements:
- Broaden the return type of `upsert_analytics_rule/3` to handle both analytics rule responses and analytics rule schema responses.

Build:
- Introduce a dedicated `ci_v30.1.yml` workflow running tests and linting against Typesense 30.1 across multiple Elixir/OTP versions.
- Update the shared LLM workflow to consume the v30.1 CI workflow and adjust its Typesense/Elixir/OTP test matrix.
- Relax linting in the v30.0 CI workflow matrix.

CI:
- Ensure CI test selection uses the `30.1` tag and that many tests now run for Typesense 30.1 alongside existing supported versions.

Deployment:
- Update the local development Docker configuration to use the Typesense 30.1 image.

Tests:
- Extend existing integration and feature tests with a `30.1` version tag so they execute against Typesense 30.1 as well as earlier supported versions.