### PR TITLE
Add 404 for Analytics.upsert_analytics_rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## major.minor.patch (yyyy.mm.dd)
 
+## 1.3.1 (2026.04.14)
+
+### Fixed
+
+* Add 404 on response for `Analytics.upsert_analytics_rule`.
+
 ## 1.3.0 (2026.04.14)
 
 ### Chore

--- a/lib/open_api_typesense/operations/analytics.ex
+++ b/lib/open_api_typesense/operations/analytics.ex
@@ -306,7 +306,8 @@ defmodule OpenApiTypesense.Analytics do
       response: [
         {200, {OpenApiTypesense.AnalyticsRule, :t}},
         {400, {OpenApiTypesense.ApiResponse, :t}},
-        {401, {OpenApiTypesense.ApiResponse, :t}}
+        {401, {OpenApiTypesense.ApiResponse, :t}},
+        {404, {OpenApiTypesense.ApiResponse, :t}}
       ],
       opts: opts
     })

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule OpenApiTypesense.MixProject do
 
   @source_url "https://github.com/jaeyson/open_api_typesense"
   @hex_url "https://hexdocs.pm/open_api_typesense"
-  @version "1.3.0"
+  @version "1.3.1"
 
   def project do
     [

--- a/priv/open_api.yml
+++ b/priv/open_api.yml
@@ -2457,6 +2457,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiResponse"
+        '404':
+          description: Analytics rule not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
     get:
       tags:
         - analytics


### PR DESCRIPTION
## Summary by Sourcery

Document 404 Not Found responses for analytics rule updates and align the analytics operation response types accordingly.

Bug Fixes:
- Handle missing analytics rules in the upsert analytics rule operation with a 404 ApiResponse.

Documentation:
- Add 404 Not Found response documentation for the analytics rule upsert endpoint in the OpenAPI spec.