### PR TITLE
Relax :poison constraint to allow 4.x, 5.x, or 6.x

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule OpenApiTypesense.MixProject do
       {:req, "~> 0.5"},
       {:excoveralls, "~> 0.18", only: [:dev, :test], runtime: false},
       {:mix_audit, "~> 2.1", only: [:dev, :test], runtime: false},
-      {:poison, "~> 6.0"},
+      {:poison, "~> 4.0 or ~> 5.0 or ~> 6.0"},
       {:oapi_generator, "~> 0.4.0", only: :dev, runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false}
     ]


### PR DESCRIPTION
The current `~> 6.0` pin blocks adoption in any project that transitively depends on a library constrained to Poison < 5 (notably Google Cloud's `google_gax`, which constrains `poison >= 3.0.0 and < 5.0.0` and is used by every `google_api_*` Hex package). Such projects can't pull `open_api_typesense >= 1.0.4` and so miss the `Enum.map_join`-over-binary fix in `Client.encode_body/1`.

`open_api_typesense` only uses two Poison APIs: `Poison.decode!(body, as: ...)` in `lib/open_api_typesense/client.ex`, and `defimpl Poison.Decoder` in each generated schema module. Both have been stable across Poison 3.x → 6.x. None of Poison 6.0's breaking changes (removed `HashSet` encoding, Erlang/Elixir minimum bumps, `:as` enhanced to accept functions) affect this library's usage.

Verified by pinning each major in turn and running `mix compile` and the local (non-container) test suite — clean on 4.0.1, 5.0.0, and 6.0.0.

## Summary by Sourcery

Build:
- Broaden Poison dependency requirement to allow 4.x, 5.x, or 6.x instead of only 6.x.