### PR TITLE
Use fork version of Poison to use Decimal v3

### DIFF
--- a/.github/workflows/ci_v30.1.yml
+++ b/.github/workflows/ci_v30.1.yml
@@ -1,7 +1,8 @@
 name: CI v30.1
 
 on:
-  workflow_call:
+  pull_request:
+    branches: ["main"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## major.minor.patch (yyyy.mm.dd)
 
+## 1.3.6 (2026.06.09)
+
+### Chore
+
+* Rename Poison to ForkPoison
+
 ## 1.3.5 (2026.06.09)
 
 ### Chore

--- a/lib/open_api_typesense/client.ex
+++ b/lib/open_api_typesense/client.ex
@@ -187,10 +187,10 @@ defmodule OpenApiTypesense.Client do
 
     case Regex.named_captures(regex, body) do
       %{"rules" => rules_string} ->
-        {:ok, Poison.decode!(rules_string, as: [mod.__struct__()])}
+        {:ok, ForkPoison.decode!(rules_string, as: [mod.__struct__()])}
 
       nil ->
-        {:ok, Poison.decode!(body, as: [mod.__struct__()])}
+        {:ok, ForkPoison.decode!(body, as: [mod.__struct__()])}
     end
   end
 
@@ -215,10 +215,10 @@ defmodule OpenApiTypesense.Client do
   end
 
   defp parse_body(_code, {:union, [{mod, _t} | _rest]}, body) do
-    case Poison.decode!(body) do
+    case ForkPoison.decode!(body) do
       list when is_list(list) ->
         Enum.map(list, fn el ->
-          case Poison.decode(el, as: mod.__struct__()) do
+          case ForkPoison.decode(el, as: mod.__struct__()) do
             {:ok, result} ->
               {:ok, result}
 
@@ -228,15 +228,15 @@ defmodule OpenApiTypesense.Client do
         end)
 
       map when is_map(map) ->
-        {:ok, Poison.decode!(body, as: mod.__struct__())}
+        {:ok, ForkPoison.decode!(body, as: mod.__struct__())}
     end
   end
 
   defp parse_body(_code, {mod, :t}, body) do
-    {:ok, Poison.decode!(body, as: mod.__struct__())}
+    {:ok, ForkPoison.decode!(body, as: mod.__struct__())}
   end
 
   defp parse_body(_code, _type, body) do
-    {:ok, Poison.decode!(body)}
+    {:ok, ForkPoison.decode!(body)}
   end
 end

--- a/lib/open_api_typesense/plugins/renderer.ex
+++ b/lib/open_api_typesense/plugins/renderer.ex
@@ -305,7 +305,7 @@ if Mix.env() == :dev do
     @spec declare_defimpl(mod :: atom()) :: Macro.t()
     defp declare_defimpl(mod) do
       quote do
-        defimpl Poison.Decoder, for: unquote(mod) do
+        defimpl ForkPoison.Decoder, for: unquote(mod) do
           def decode(value, %{as: struct}) do
             mod =
               case struct do

--- a/lib/open_api_typesense/schemas/analytics_events_response.ex
+++ b/lib/open_api_typesense/schemas/analytics_events_response.ex
@@ -8,7 +8,7 @@ defmodule OpenApiTypesense.AnalyticsEventsResponse do
 
   defstruct [:events]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.AnalyticsEventsResponse) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.AnalyticsEventsResponse) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/analytics_rule_parameters_source.ex
+++ b/lib/open_api_typesense/schemas/analytics_rule_parameters_source.ex
@@ -11,7 +11,7 @@ defmodule OpenApiTypesense.AnalyticsRuleParametersSource do
 
   defstruct [:collections, :events]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.AnalyticsRuleParametersSource) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.AnalyticsRuleParametersSource) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/analytics_rules_retrieve_schema.ex
+++ b/lib/open_api_typesense/schemas/analytics_rules_retrieve_schema.ex
@@ -8,7 +8,7 @@ defmodule OpenApiTypesense.AnalyticsRulesRetrieveSchema do
 
   defstruct [:rules]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.AnalyticsRulesRetrieveSchema) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.AnalyticsRulesRetrieveSchema) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/api_keys_response.ex
+++ b/lib/open_api_typesense/schemas/api_keys_response.ex
@@ -8,7 +8,7 @@ defmodule OpenApiTypesense.ApiKeysResponse do
 
   defstruct [:keys]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.ApiKeysResponse) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.ApiKeysResponse) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/collection_aliases_response.ex
+++ b/lib/open_api_typesense/schemas/collection_aliases_response.ex
@@ -8,7 +8,7 @@ defmodule OpenApiTypesense.CollectionAliasesResponse do
 
   defstruct [:aliases]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.CollectionAliasesResponse) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.CollectionAliasesResponse) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/collection_response.ex
+++ b/lib/open_api_typesense/schemas/collection_response.ex
@@ -32,7 +32,7 @@ defmodule OpenApiTypesense.CollectionResponse do
     token_separators: []
   ]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.CollectionResponse) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.CollectionResponse) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/collection_schema.ex
+++ b/lib/open_api_typesense/schemas/collection_schema.ex
@@ -28,7 +28,7 @@ defmodule OpenApiTypesense.CollectionSchema do
     token_separators: []
   ]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.CollectionSchema) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.CollectionSchema) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/collection_update_schema.ex
+++ b/lib/open_api_typesense/schemas/collection_update_schema.ex
@@ -12,7 +12,7 @@ defmodule OpenApiTypesense.CollectionUpdateSchema do
 
   defstruct [:fields, :metadata, :synonym_sets]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.CollectionUpdateSchema) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.CollectionUpdateSchema) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/curation_item_create_schema.ex
+++ b/lib/open_api_typesense/schemas/curation_item_create_schema.ex
@@ -36,7 +36,7 @@ defmodule OpenApiTypesense.CurationItemCreateSchema do
     :stop_processing
   ]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.CurationItemCreateSchema) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.CurationItemCreateSchema) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/curation_item_schema.ex
+++ b/lib/open_api_typesense/schemas/curation_item_schema.ex
@@ -36,7 +36,7 @@ defmodule OpenApiTypesense.CurationItemSchema do
     :stop_processing
   ]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.CurationItemSchema) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.CurationItemSchema) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/curation_set_create_schema.ex
+++ b/lib/open_api_typesense/schemas/curation_set_create_schema.ex
@@ -11,7 +11,7 @@ defmodule OpenApiTypesense.CurationSetCreateSchema do
 
   defstruct [:description, :items]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.CurationSetCreateSchema) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.CurationSetCreateSchema) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/curation_set_schema.ex
+++ b/lib/open_api_typesense/schemas/curation_set_schema.ex
@@ -12,7 +12,7 @@ defmodule OpenApiTypesense.CurationSetSchema do
 
   defstruct [:description, :items, :name]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.CurationSetSchema) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.CurationSetSchema) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/facet_counts.ex
+++ b/lib/open_api_typesense/schemas/facet_counts.ex
@@ -13,7 +13,7 @@ defmodule OpenApiTypesense.FacetCounts do
 
   defstruct [:counts, :field_name, :sampled, :stats]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.FacetCounts) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.FacetCounts) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/multi_search_result.ex
+++ b/lib/open_api_typesense/schemas/multi_search_result.ex
@@ -11,7 +11,7 @@ defmodule OpenApiTypesense.MultiSearchResult do
 
   defstruct [:conversation, :results]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.MultiSearchResult) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.MultiSearchResult) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/multi_search_result_item.ex
+++ b/lib/open_api_typesense/schemas/multi_search_result_item.ex
@@ -40,7 +40,7 @@ defmodule OpenApiTypesense.MultiSearchResultItem do
     :union_request_params
   ]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.MultiSearchResultItem) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.MultiSearchResultItem) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/multi_search_searches_parameter.ex
+++ b/lib/open_api_typesense/schemas/multi_search_searches_parameter.ex
@@ -11,7 +11,7 @@ defmodule OpenApiTypesense.MultiSearchSearchesParameter do
 
   defstruct [:searches, union: false]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.MultiSearchSearchesParameter) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.MultiSearchSearchesParameter) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/presets_retrieve_schema.ex
+++ b/lib/open_api_typesense/schemas/presets_retrieve_schema.ex
@@ -8,7 +8,7 @@ defmodule OpenApiTypesense.PresetsRetrieveSchema do
 
   defstruct [:presets]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.PresetsRetrieveSchema) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.PresetsRetrieveSchema) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/search_grouped_hit.ex
+++ b/lib/open_api_typesense/schemas/search_grouped_hit.ex
@@ -12,7 +12,7 @@ defmodule OpenApiTypesense.SearchGroupedHit do
 
   defstruct [:found, :group_key, :hits]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.SearchGroupedHit) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.SearchGroupedHit) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/search_override.ex
+++ b/lib/open_api_typesense/schemas/search_override.ex
@@ -36,7 +36,7 @@ defmodule OpenApiTypesense.SearchOverride do
     :stop_processing
   ]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.SearchOverride) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.SearchOverride) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/search_override_schema.ex
+++ b/lib/open_api_typesense/schemas/search_override_schema.ex
@@ -34,7 +34,7 @@ defmodule OpenApiTypesense.SearchOverrideSchema do
     :stop_processing
   ]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.SearchOverrideSchema) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.SearchOverrideSchema) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/search_overrides_response.ex
+++ b/lib/open_api_typesense/schemas/search_overrides_response.ex
@@ -8,7 +8,7 @@ defmodule OpenApiTypesense.SearchOverridesResponse do
 
   defstruct [:overrides]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.SearchOverridesResponse) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.SearchOverridesResponse) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/search_result.ex
+++ b/lib/open_api_typesense/schemas/search_result.ex
@@ -36,7 +36,7 @@ defmodule OpenApiTypesense.SearchResult do
     :union_request_params
   ]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.SearchResult) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.SearchResult) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/search_result_hit.ex
+++ b/lib/open_api_typesense/schemas/search_result_hit.ex
@@ -28,7 +28,7 @@ defmodule OpenApiTypesense.SearchResultHit do
     :vector_distance
   ]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.SearchResultHit) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.SearchResultHit) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/search_synonyms_response.ex
+++ b/lib/open_api_typesense/schemas/search_synonyms_response.ex
@@ -8,7 +8,7 @@ defmodule OpenApiTypesense.SearchSynonymsResponse do
 
   defstruct [:synonyms]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.SearchSynonymsResponse) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.SearchSynonymsResponse) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/stemming_dictionary.ex
+++ b/lib/open_api_typesense/schemas/stemming_dictionary.ex
@@ -8,7 +8,7 @@ defmodule OpenApiTypesense.StemmingDictionary do
 
   defstruct [:id, :words]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.StemmingDictionary) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.StemmingDictionary) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/stopwords_sets_retrieve_all_schema.ex
+++ b/lib/open_api_typesense/schemas/stopwords_sets_retrieve_all_schema.ex
@@ -8,7 +8,7 @@ defmodule OpenApiTypesense.StopwordsSetsRetrieveAllSchema do
 
   defstruct [:stopwords]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.StopwordsSetsRetrieveAllSchema) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.StopwordsSetsRetrieveAllSchema) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/synonym_set_create_schema.ex
+++ b/lib/open_api_typesense/schemas/synonym_set_create_schema.ex
@@ -8,7 +8,7 @@ defmodule OpenApiTypesense.SynonymSetCreateSchema do
 
   defstruct [:items]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.SynonymSetCreateSchema) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.SynonymSetCreateSchema) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/lib/open_api_typesense/schemas/synonym_set_schema.ex
+++ b/lib/open_api_typesense/schemas/synonym_set_schema.ex
@@ -8,7 +8,7 @@ defmodule OpenApiTypesense.SynonymSetSchema do
 
   defstruct [:items, :name]
 
-  defimpl(Poison.Decoder, for: OpenApiTypesense.SynonymSetSchema) do
+  defimpl(ForkPoison.Decoder, for: OpenApiTypesense.SynonymSetSchema) do
     def decode(value, %{as: struct}) do
       mod =
         case struct do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule OpenApiTypesense.MixProject do
 
   @source_url "https://github.com/jaeyson/open_api_typesense"
   @hex_url "https://hexdocs.pm/open_api_typesense"
-  @version "1.3.5"
+  @version "1.3.6"
 
   def project do
     [


### PR DESCRIPTION
Closes #54

## Summary by Sourcery

Switch JSON decoding to a forked Poison library across client and schema modules and bump the library version.

Enhancements:
- Replace Poison JSON decoding and decoder protocol implementations with ForkPoison equivalents to use the forked library.

Build:
- Bump project version to 1.3.6 in mix.exs.

Documentation:
- Document the change to ForkPoison in the changelog with a new 1.3.6 release entry.